### PR TITLE
Change INT_MAX to 4 bytes rather than 8 to fix overflow encoding (fixes #1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clp_logging"
-version = "0.0.4"
+version = "0.0.3"
 license = { text = "Apache License 2.0" }
 authors = [
     { name="david lion", email="david.lion@yscope.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clp_logging"
-version = "0.0.3"
+version = "0.0.4"
 license = { text = "Apache License 2.0" }
 authors = [
     { name="david lion", email="david.lion@yscope.com" },

--- a/src/clp_logging/protocol.py
+++ b/src/clp_logging/protocol.py
@@ -6,7 +6,7 @@ from typing_extensions import Final, Literal
 SIZEOF_INT: Final[int] = 4
 SIZEOF_SHORT: Final[int] = 2
 SIZEOF_BYTE: Final[int] = 1
-INT_MAX: Final[int] = (1 << 63) - 1
+INT_MAX: Final[int] = (1 << 31) - 1
 INT_MIN: Final[int] = ~INT_MAX
 USHORT_MAX: Final[int] = (1 << 16) - 1
 SHORT_MAX: Final[int] = (1 << 15) - 1

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -142,6 +142,7 @@ class TestCLPBase(unittest.TestCase):
     def test_dict(self) -> None:
         self.logger.info("textint test1234")
         self.logger.info("texteq=var")
+        self.logger.info(f">32bit int: {2**32}")
         self.compare_output()
 
     def test_combo(self) -> None:


### PR DESCRIPTION
# References
#1 

# Description
Changes the value of `INT_MAX` to be 4 bytes rather than 8 to fix an overflow error when encoding as integers greater than 4 bytes are unsupported.

# Validation performed
Added unit test to `test_dict` in `tests/test_handlers.py` that logs 2^32.