### PR TITLE
Support log lengths up to int_max by switching the listener to a server model with stream sockets.

### DIFF
--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -273,7 +273,7 @@ class CLPSockListener:
                 Thread(
                     target=CLPSockListener._handle_client, args=(conn, log_queue), daemon=False
                 ).start()
-            except socket.timeout:  # replaced with TimeoutError in python 3.10
+            except socket.timeout:
                 pass
         sock.close()
         sock_path.unlink()

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -5,16 +5,20 @@ import time
 from datetime import datetime
 from math import floor
 from pathlib import Path
+from queue import Empty, Queue
 from signal import signal, SIGINT, SIGTERM
-from socket import socket, AF_UNIX, SOCK_DGRAM
+import socket
+from threading import Thread
 import sys
 from types import FrameType
-from typing import ClassVar, IO, Optional, Tuple
+from typing import ClassVar, IO, Optional, Tuple, TypeVar
 
 from zstandard import ZstdCompressor, ZstdCompressionWriter
 
 from clp_logging.encoder import CLPEncoder
-from clp_logging.protocol import EOF_CHAR
+from clp_logging.protocol import BYTE_ORDER, EOF_CHAR, SIZEOF_INT, UINT_MAX
+
+# Note: no need to quote "Queue[bytes]" in python 3.9
 
 DEFAULT_LOG_FORMAT: str = " %(levelname)s %(name)s %(message)s"
 WARN_PREFIX: str = "[WARN][clp_logging]"
@@ -105,15 +109,15 @@ class CLPSockListener:
     _signaled: ClassVar[bool] = False
 
     @staticmethod
-    def _try_bind(sock: socket, sock_path: Path) -> int:
+    def _try_bind(sock: socket.socket, sock_path: Path) -> int:
         """
         Bind will fail if the socket file exists due to:
             a. Another listener currently exists and is running
                 -> try to connect to it
             b. A listener existed in the past, but is now gone
                 -> recovery unsupported
-        :return: >= 0 on success or < 0 on failure. 0: bind succeeds, 1:
-        connect succeeds, -1: nothing worked
+        :return: 0 on success or < 0 on failure. 0: bind succeeds, -1: connect
+        succeeds, -2: nothing worked
         """
         try:
             sock.bind(str(sock_path))
@@ -121,37 +125,74 @@ class CLPSockListener:
         except OSError:
             pass
 
-        if sock.connect_ex(str(sock_path)) == 0:
+        test_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        if test_sock.connect_ex(str(sock_path)) == 0:
+            test_sock.close()
             sock.close()
-            return 1
-        else:
             return -1
+        else:
+            return -2
 
     @staticmethod
     def _exit_handler(signum: int, frame: Optional[FrameType]) -> None:
         _signaled = True
 
     @staticmethod
-    def _run(
-        parent_fd: int,
-        log_path: Path,
-        sock_path: Path,
-        timestamp_format: Optional[str],
-        timezone: Optional[str],
+    def _handle_client(
+        conn: socket.socket,
+        log_queue: "Queue[bytes]",
     ) -> int:
         """
-        The `CLPSockListener` server function run in a new process.
-        Writes 1 byte back to parent process for synchronization.
-        :return: 0 on successful exit, -1 if `CLPSockListener._try_bind` fails
+        Continuously reads from an individual `CLPSockHandler` and sends the
+        received messages to the aggregator thread.
+        :param conn: Client socket where encoded messages and their length are
+        received.
+        :param log_queue: Queue with `CLPSockListener._aggregator` thread to
+        write encoded messages.
         """
-        sock = socket(AF_UNIX, SOCK_DGRAM)
-        ret: int = CLPSockListener._try_bind(sock, sock_path)
-        os.write(parent_fd, b"\x00")
-        if ret < 0:
-            return ret
+        size_buf: bytearray = bytearray(SIZEOF_INT)
+        while not CLPSockListener._signaled:
+            try:
+                read: int = conn.recv_into(size_buf, SIZEOF_INT)
+                assert read == SIZEOF_INT
+                size: int = int.from_bytes(size_buf, BYTE_ORDER)
+                if size == 0:
+                    log_queue.put(EOF_CHAR)
+                    break
+                buf: bytearray = bytearray(size)
+                view: memoryview = memoryview(buf)
+                i: int = 0
+                while i < size:
+                    read = conn.recv_into(view[i:], size)
+                    i += read
+                log_queue.put(buf)
+            except socket.timeout:  # replaced with TimeoutError in python 3.10
+                pass
+        return 0
 
-        signal(SIGINT, CLPSockListener._exit_handler)
-        signal(SIGTERM, CLPSockListener._exit_handler)
+    @staticmethod
+    def _aggregator(
+        log_path: Path,
+        log_queue: "Queue[bytes]",
+        timestamp_format: Optional[str],
+        timezone: Optional[str],
+        timeout: int,
+    ) -> int:
+        """
+        Continuously receive encoded messages from
+        `CLPSockListener._handle_client` threads and write them to a Zstandard
+        stream.
+        :param log_path: Path to log file and used to derive socket name.
+        :param log_queue: Queue with `CLPSockListener._handle_client` threads
+        to write encoded messages.
+        :param timestamp_format: Timestamp format written in preamble to be use
+        when generating the logs with a reader.
+        :param timezone: Timezone written in preamble to be use when generating
+        the timestamp from Unix epoch time.
+        :param timeout: timeout to prevent `Queue.get` from never returning and
+        not closing properly on signal/EOF_CHAR.
+        :return: 0 on successful exit
+        """
         cctx: ZstdCompressor = ZstdCompressor()
         timestamp_format, timezone = _init_timeinfo(timestamp_format, timezone)
         last_timestamp_ms: int = floor(time.time() * 1000)  # convert to ms and truncate
@@ -159,15 +200,76 @@ class CLPSockListener:
         with log_path.open("ab") as log, cctx.stream_writer(log) as zstream:
             zstream.write(CLPEncoder.emit_preamble(last_timestamp_ms, timestamp_format, timezone))
             while not CLPSockListener._signaled:
-                buf: bytes = sock.recv(4096)
-                if buf == EOF_CHAR:
+                msg: bytes
+                try:
+                    msg = log_queue.get(timeout=timeout)
+                except Empty:
+                    continue
+                if msg == EOF_CHAR:
                     break
                 ts_buf: bytearray = bytearray()
                 last_timestamp_ms = CLPEncoder.encode_timestamp(last_timestamp_ms, ts_buf)
-                zstream.write(buf)
+                zstream.write(msg)
                 zstream.write(ts_buf)
             zstream.write(EOF_CHAR)
             zstream.flush()
+        # tell _server to exit
+        CLPSockListener._signaled = True
+        return 0
+
+    @staticmethod
+    def _server(
+        parent_fd: int,
+        log_path: Path,
+        sock_path: Path,
+        timestamp_format: Optional[str],
+        timezone: Optional[str],
+        timeout: int,
+    ) -> int:
+        """
+        The `CLPSockListener` server function run in a new process.
+        Writes 1 byte back to parent process for synchronization.
+        :param parent_fd: Used to communicate to parent `CLPSockHandler`
+        process that `_try_bind` has finished.
+        :param log_path: Path to log file.
+        :param sock_path: Path to socket file.
+        :param timestamp_format: Timestamp format written in preamble to be use
+        when generating the logs with a reader.
+        :param timezone: Timezone written in preamble to be use when generating
+        the timestamp from Unix epoch time.
+        :param timeout: timeout to prevent block operations from never
+        returning and not closing properly on signal/EOF_CHAR
+        :return: 0 on successful exit, -1 if `CLPSockListener._try_bind` fails
+        """
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        log_queue: "Queue[bytes]" = Queue()
+        ret: int = CLPSockListener._try_bind(sock, sock_path)
+        sock.listen()
+        os.write(parent_fd, b"\x00")
+        if ret < 0:
+            return ret
+
+        signal(SIGINT, CLPSockListener._exit_handler)
+        signal(SIGTERM, CLPSockListener._exit_handler)
+
+        Thread(
+            target=CLPSockListener._aggregator,
+            args=(log_path, log_queue, timestamp_format, timezone, timeout),
+            daemon=False,
+        ).start()
+
+        while not CLPSockListener._signaled:
+            conn: socket.socket
+            addr: Tuple[str, int]
+            try:
+                conn, addr = sock.accept()
+                conn.settimeout(timeout)
+                Thread(
+                    target=CLPSockListener._handle_client, args=(conn, log_queue), daemon=False
+                ).start()
+            except socket.timeout:  # replaced with TimeoutError in python 3.10
+                pass
         sock.close()
         sock_path.unlink()
         return 0
@@ -177,9 +279,10 @@ class CLPSockListener:
         log_path: Path,
         timestamp_format: Optional[str],
         timezone: Optional[str],
+        timeout: int,
     ) -> int:
         """
-        Fork a process running `CLPSockListener._run` and use `os.setsid()`
+        Fork a process running `CLPSockListener._server` and use `os.setsid()`
         to give it another session id (and process group id). The parent will
         not return until the forked listener has either bound the socket
         or finished trying to.
@@ -188,6 +291,8 @@ class CLPSockListener:
         when generating the logs with a reader.
         :param timezone: Timezone written in preamble to be use when generating
         the timestamp from Unix epoch time.
+        :param timeout: timeout to prevent block operations from never
+        returning and not closing properly on signal/EOF_CHAR
         :return: child pid
         """
         sock_path: Path = log_path.with_suffix(".sock")
@@ -197,7 +302,11 @@ class CLPSockListener:
         pid: int = os.fork()
         if pid == 0:
             os.setsid()
-            sys.exit(CLPSockListener._run(wfd, log_path, sock_path, timestamp_format, timezone))
+            sys.exit(
+                CLPSockListener._server(
+                    wfd, log_path, sock_path, timestamp_format, timezone, timeout
+                )
+            )
         else:
             os.read(rfd, 1)
         return pid
@@ -217,7 +326,7 @@ class CLPSockHandler(CLPBaseHandler):
         create_listener: bool = False,
         timestamp_format: Optional[str] = None,
         timezone: Optional[str] = None,
-        timeout: int = 1,
+        timeout: int = 2,
     ) -> None:
         """
         Constructor method that optionally spawns a `CLPSockListener`.
@@ -230,18 +339,20 @@ class CLPSockHandler(CLPBaseHandler):
         the logs with a reader. (Only used when creating a listener.)
         :param timezone: Timezone written in preamble to be use when generating the
         timestamp from Unix epoch time. (Only used when creating a listener.)
-        :param timeout: `socket.socket` timeout (defaults to 1)
+        :param timeout: timeout to prevent blocking operations from never
+        returning and not closing properly on signal/EOF_CHAR
         """
         super().__init__()
         sock_path: Path = log_path.with_suffix(".sock")
         self.closed: bool = False
-        self.sock: socket = socket(AF_UNIX, SOCK_DGRAM)
-        self.sock.settimeout(timeout)
+        self.sock: socket.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.listener_pid: int = 0
 
         if self.sock.connect_ex(str(sock_path)) != 0:
             if create_listener:
-                self.listener_pid = CLPSockListener.fork(log_path, timestamp_format, timezone)
+                self.listener_pid = CLPSockListener.fork(
+                    log_path, timestamp_format, timezone, timeout
+                )
 
             # If we fail to connect again, the listener failed to resolve any
             # issues, so we raise an exception as there is nothing new to try
@@ -256,7 +367,13 @@ class CLPSockHandler(CLPBaseHandler):
         try:
             if self.closed:
                 raise RuntimeError("Socket already closed")
-            self.sock.send(CLPEncoder.encode_message(msg.encode()))
+            clp_msg: bytearray = CLPEncoder.encode_message(msg.encode())
+            size: int = len(clp_msg)
+            if size > UINT_MAX:
+                raise NotImplementedError("Encoded message > unsigned int currently unsupported")
+            sizeb: bytes = size.to_bytes(SIZEOF_INT, BYTE_ORDER)
+            self.sock.sendall(sizeb)
+            self.sock.sendall(clp_msg)
         except Exception as e:
             self.sock.close()
             raise e
@@ -285,7 +402,7 @@ class CLPSockHandler(CLPBaseHandler):
         self.closed = True
 
     def stop_listener(self) -> None:
-        self.sock.send(EOF_CHAR)
+        self.sock.send((0).to_bytes(SIZEOF_INT, BYTE_ORDER))
         self.close()
 
 

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -164,10 +164,15 @@ class CLPSockListener:
                 i: int = 0
                 while i < size:
                     read = conn.recv_into(view[i:], size)
+                    if read == 0:
+                        raise OSError("handler conn.recv_into return 0 before finishing")
                     i += read
                 log_queue.put(buf)
             except socket.timeout:  # replaced with TimeoutError in python 3.10
                 pass
+            except OSError:
+                conn.close()
+                raise
         return 0
 
     @staticmethod

--- a/src/clp_logging/protocol.py
+++ b/src/clp_logging/protocol.py
@@ -6,6 +6,7 @@ from typing_extensions import Final, Literal
 SIZEOF_INT: Final[int] = 4
 SIZEOF_SHORT: Final[int] = 2
 SIZEOF_BYTE: Final[int] = 1
+UINT_MAX: Final[int] = (1 << 32) - 1
 INT_MAX: Final[int] = (1 << 31) - 1
 INT_MIN: Final[int] = ~INT_MAX
 USHORT_MAX: Final[int] = (1 << 16) - 1


### PR DESCRIPTION
# Description
* Support log lengths up to int_max by switching the listener to a server model with stream sockets.
* Switched single listener thread to:
    1. a server thread that accepts handler connections
    2. an aggregation thread that receives encoded logs from a queue and writes them to a Zstandard stream
    3. N per-handler threads that receive encoded logs from a stream socket and write them to the aggregation queue
* Fixes `CLPBaseReader._readinto` bug where growing the buffer did not properly copy existing valid memory.

# Validation performed
Added unit test that logs 2mb messages.

