### PR TITLE
Timezone uses TZID (fixes #9); rewords Log fields; adds pretty print logtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,14 @@ CLPSockHandler(Path("example.clp.zst")).stop_listener()
 
 #### Example code: CLPFileReader
 ```python
-import logging
 from pathlib import Path
+from typing import List
+
 from clp_logging.readers import CLPFileReader, Log
 
 # create a list of all Log objects
 log_objects: List[Log] = []
-with CLPFileReader(Path("example.clp.zst") as clp_reader:
+with CLPFileReader(Path("example.clp.zst")) as clp_reader:
     for log in clp_reader:
         log_objects.append(log)
 ```
@@ -134,7 +135,7 @@ result in a test reporting a false positive error.
 1. Create and enter a virtual environment:
     `python -m venv venv; .  ./venv/bin/activate`
 2. Install:
-    `pip install dist/clp_logging-0.0.1-py3-none-any.whl` or `pip install -e .`
+    `pip install dist/clp_logging-*-py3-none-any.whl` or `pip install -e .`
 3. Run unittest:
     `python -m unittest -bv`
 

--- a/src/clp_logging/encoder.py
+++ b/src/clp_logging/encoder.py
@@ -22,8 +22,8 @@ from clp_logging.protocol import (
     METADATA_TZ_ID_KEY,
     METADATA_VERSION_KEY,
     METADATA_VERSION_VALUE,
-    RE_DELIM_VAR,
-    RE_SUB_DELIM_VAR,
+    RE_ESCAPE,
+    RE_SUB_ESCAPE,
     TIMESTAMP_DELTA_BYTE,
     TIMESTAMP_DELTA_SHORT,
     TIMESTAMP_DELTA_INT,
@@ -73,8 +73,8 @@ class CLPEncoder:
         with each message.
         :param timestamp_format: Timestamp format to be use when generating the
         logs with a reader.
-        :param timezone: Timezone to be use when generating the timestamp from
-        Unix epoch time.
+        :param timezone: Timezone in TZID format to be use when generating the
+        timestamp from Unix epoch time.
         :raises NotImplementedError: If metadata length too large
         :return: The encoded preamble
         """
@@ -293,7 +293,7 @@ class CLPEncoder:
         `logging.LogRecord`
         """
         # Escape dangerous bytes
-        msg = RE_DELIM_VAR.sub(RE_SUB_DELIM_VAR, msg)
+        msg = RE_ESCAPE.sub(RE_SUB_ESCAPE, msg)
 
         clp_msg: bytearray = bytearray()
         logtype: bytearray = bytearray()

--- a/src/clp_logging/encoder.py
+++ b/src/clp_logging/encoder.py
@@ -22,8 +22,8 @@ from clp_logging.protocol import (
     METADATA_TZ_ID_KEY,
     METADATA_VERSION_KEY,
     METADATA_VERSION_VALUE,
-    RE_ESCAPE,
-    RE_SUB_ESCAPE,
+    RE_DELIM_VAR_ESCAPE,
+    RE_SUB_DELIM_VAR_ESCAPE,
     TIMESTAMP_DELTA_BYTE,
     TIMESTAMP_DELTA_SHORT,
     TIMESTAMP_DELTA_INT,
@@ -293,7 +293,7 @@ class CLPEncoder:
         `logging.LogRecord`
         """
         # Escape dangerous bytes
-        msg = RE_ESCAPE.sub(RE_SUB_ESCAPE, msg)
+        msg = RE_DELIM_VAR_ESCAPE.sub(RE_SUB_DELIM_VAR_ESCAPE, msg)
 
         clp_msg: bytearray = bytearray()
         logtype: bytearray = bytearray()

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -13,6 +13,7 @@ import sys
 from types import FrameType
 from typing import ClassVar, IO, Optional, Tuple, TypeVar
 
+import dateutil.tz
 from zstandard import ZstdCompressor, ZstdCompressionWriter
 
 from clp_logging.encoder import CLPEncoder
@@ -34,13 +35,17 @@ def _init_timeinfo(fmt: Optional[str], tz: Optional[str]) -> Tuple[str, str]:
     readers.)
     :param fmt: Timestamp format written in preamble to be used when generating
     the logs with a reader.
-    :param tz: Timezone written in preamble to be used when generating the
-    timestamp from Unix epoch time.
+    :param tz: Timezone in TZID format written in preamble to be used when
+    generating the timestamp from Unix epoch time.
     """
     if not fmt:
         fmt = "yyyy-MM-d H:m:s.A"
     if not tz:
-        tz = datetime.now().astimezone().strftime("%z")
+        tzf = dateutil.tz.gettz()
+        if tzf:
+            if tzf._filename == "/etc/localtime":
+                tzp = Path.resolve(Path(tzf._filename))
+            tz = "/".join([tzp.parent.name, tzp.name])
     return fmt, tz
 
 

--- a/src/clp_logging/protocol.py
+++ b/src/clp_logging/protocol.py
@@ -47,8 +47,9 @@ ESCAPE_CHAR: bytes = b"\\"
 # Thus these need to be updated manually if the escape character ever changes
 RE_UNESCAPE: Pattern[bytes] = re.compile(rb"\\([\x11\x12\x13\\])")
 RE_SUB_UNESCAPE: bytes = rb"\1"
-RE_DELIM_VAR: Pattern[bytes] = re.compile(rb"([\x11\x12\x13\\])")
-RE_SUB_DELIM_VAR: bytes = rb"\\\1"
+RE_ESCAPE: Pattern[bytes] = re.compile(rb"([\x11\x12\x13\\])")
+RE_SUB_ESCAPE: bytes = rb"\\\1"
+RE_DELIM_VAR: Pattern[bytes] = re.compile(rb"([\x11\x12\x13])")
 
 # 0x10-0x1f reserved for variable-related constants
 # 0x20-0x2f reserved for logtype-related constants

--- a/src/clp_logging/protocol.py
+++ b/src/clp_logging/protocol.py
@@ -45,10 +45,10 @@ ESCAPE_CHAR: bytes = b"\\"
 # for raw/literal string applies to the format string itself and not the delim
 # variable we are substituting in
 # Thus these need to be updated manually if the escape character ever changes
-RE_UNESCAPE: Pattern[bytes] = re.compile(rb"\\([\x11\x12\x13\\])")
-RE_SUB_UNESCAPE: bytes = rb"\1"
-RE_ESCAPE: Pattern[bytes] = re.compile(rb"([\x11\x12\x13\\])")
-RE_SUB_ESCAPE: bytes = rb"\\\1"
+RE_DELIM_VAR_UNESCAPE: Pattern[bytes] = re.compile(rb"\\([\x11\x12\x13\\])")
+RE_SUB_DELIM_VAR_UNESCAPE: bytes = rb"\1"
+RE_DELIM_VAR_ESCAPE: Pattern[bytes] = re.compile(rb"([\x11\x12\x13\\])")
+RE_SUB_DELIM_VAR_ESCAPE: bytes = rb"\\\1"
 RE_DELIM_VAR: Pattern[bytes] = re.compile(rb"([\x11\x12\x13])")
 
 # 0x10-0x1f reserved for variable-related constants

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import IO, Iterator, List, Match, Optional, Type, Union
 
+import dateutil.tz
 from sys import stderr
 from zstandard import ZstdDecompressor, ZstdDecompressionReader
 
@@ -36,67 +37,70 @@ class Log:
     decoded fields after `_decode` has been called. `Log` objects should be
     created using reader iterators to ensure they are valid.
     :param timestamp_ms: Time in ms since Unix epoch
-    :param _logtype: Encoded logtype
-    :param _vars: Encoded and untyped variables
-    :param variables: Yyped and decoded variables
+    :param encoded_logtype: Encoded logtype
+    :param encoded_variables: Encoded and untyped variables
+    :param variables: Typed and decoded variables
     :param msg: Complete decoded log with no `Formatter` components (`msg`
     field of a `logging.record`)
-    :param log: Complete decoded log with all `Formatter` components
+    :param formatted_msg: Complete decoded log with all `Formatter` components
     """
 
     def __init__(self) -> None:
         self.timestamp_ms: int
-        self._logtype: bytes
-        self._vars: List[bytes] = []
+        self.encoded_logtype: bytes
+        self.encoded_variables: List[bytes] = []
+
+        self.logtype: str
         self.variables: List[Union[int, float, str]] = []
         self.msg: str
-        self.log: str
+        self.formatted_msg: str
 
     def __str__(self) -> str:
-        return self.log
+        return self.formatted_msg
 
     def _decode(self, timestamp_format: str, timezone: Optional[tzinfo]) -> int:
         """
-        Populate the `variables`, `msg`, and `log` fields by decoding the
-        encoded `_logtype and `_vars`.
+        Populate the `variables`, `msg`, and `formatted_msg` fields by decoding
+        the encoded `encoded_logtype and `encoded_variables`.
         :param timestamp_format: Currently ignored due to compatibility issues
         with other language libraries. (`datetime.isoformat` is always used.)
         :param timezone: Timezone to use when creating the timestamp from Unix
         epoch time.
         :return: 0 on success, < 0 on error
         """
-        var_delim_matchs: List[Match[bytes]] = list(RE_DELIM_VAR.finditer(self._logtype))
-        if not len(self._vars) == len(var_delim_matchs):
+        self.logtype = str(RE_DELIM_VAR.sub(b"<var>", self.encoded_logtype))
+        var_delim_matchs: List[Match[bytes]] = list(RE_DELIM_VAR.finditer(self.encoded_logtype))
+        if not len(self.encoded_variables) == len(var_delim_matchs):
             raise RuntimeError("Number of var delims in logtype does not match stored vars")
 
         msg: str = ""
         pos: int = 0
         for i, var_delim_match in enumerate(var_delim_matchs):
             var_start: int = var_delim_match.start()
-            msg += self._logtype[pos:var_start].decode()
+            msg += self.encoded_logtype[pos:var_start].decode()
 
             var_delim: bytes = var_delim_match.group(0)
             var_str: str
             if var_delim == DELIM_DICT:
-                var_str = CLPDecoder.decode_dict(self._vars[i])
+                var_str = CLPDecoder.decode_dict(self.encoded_variables[i])
                 self.variables.append(var_str)
             elif var_delim == DELIM_INT:
                 var_int: int
-                var_int, var_str = CLPDecoder.decode_int(self._vars[i])
+                var_int, var_str = CLPDecoder.decode_int(self.encoded_variables[i])
                 self.variables.append(var_int)
             elif var_delim == DELIM_FLOAT:
                 var_float: float
-                var_float, var_str = CLPDecoder.decode_float(self._vars[i])
+                var_float, var_str = CLPDecoder.decode_float(self.encoded_variables[i])
                 self.variables.append(var_float)
             else:
                 raise RuntimeError("Unknown delimiter")
 
             msg += var_str
             pos = var_delim_match.end()
-        msg += self._logtype[pos:].decode()
+        msg += self.encoded_logtype[pos:].decode()
         self.msg = msg
         dt: datetime = datetime.fromtimestamp(self.timestamp_ms / 1000, timezone)
-        self.log = dt.isoformat(sep=" ", timespec="milliseconds") + self.msg
+        self.formatted_msg = dt.isoformat(sep=" ", timespec="milliseconds") + self.msg
         return 0
 
 
@@ -150,7 +154,7 @@ class CLPBaseReader(metaclass=ABCMeta):
         if self.metadata:
             self.last_timestamp_ms = int(self.metadata[METADATA_REFERENCE_TIMESTAMP_KEY])
             self.timestamp_format = self.metadata[METADATA_TIMESTAMP_PATTERN_KEY]
-            self.timezone = datetime.strptime(self.metadata[METADATA_TZ_ID_KEY], "%z").tzinfo
+            self.timezone = dateutil.tz.gettz(self.metadata[METADATA_TZ_ID_KEY])
         return self.pos
 
     @abstractmethod
@@ -246,9 +250,6 @@ class CLPBaseReader(metaclass=ABCMeta):
         :return: index read to in `view` (start of next log), 0 on EOF, < 0 on
         error
         """
-        variables: List[bytes] = []
-        logtype: bytes
-
         while True:
             while True:
                 token_type: int
@@ -302,9 +303,9 @@ class CLPBaseReader(metaclass=ABCMeta):
             if token_type != VAR_COMPACT_ENCODING[0]:
                 # remove any escaping done during encoding
                 t = RE_UNESCAPE.sub(RE_SUB_UNESCAPE, t)
-            log._vars.append(t)
+            log.encoded_variables.append(t)
         elif token_id == ID_LOGTYPE:
-            log._logtype = RE_UNESCAPE.sub(RE_SUB_UNESCAPE, token)
+            log.encoded_logtype = RE_UNESCAPE.sub(RE_SUB_UNESCAPE, bytes(token))
         elif token_id == ID_TIMESTAMP:
             delta_ms: int = int.from_bytes(token, BYTE_ORDER, signed=True)
             log.timestamp_ms = self.last_timestamp_ms + delta_ms
@@ -347,4 +348,4 @@ class CLPFileReader(CLPStreamReader):
 
     def dump(self) -> None:
         for log in self:
-            stderr.write(log.log)
+            stderr.write(log.formatted_msg)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -89,7 +89,7 @@ class TestCLPBase(unittest.TestCase):
 
     def read_clp(self) -> List[str]:
         with CLPFileReader(self.clp_log_path) as logf:
-            return [log.log for log in logf]
+            return [log.formatted_msg for log in logf]
 
     def read_raw(self) -> List[str]:
         with open(self.raw_log_path, "r") as logf:


### PR DESCRIPTION
# References
#9

# Description
Updates timezone to use TZID (rather than the offset) both for encoding and decoding. This fixes #9 and makes the Python and Java libraries compatible.
Additionally, the `Log` object's fields have been renamed to improve readability.


# Validation performed
Validated using two logs that produce the error. All unit tests passing.

