### PR TITLE
More descriptive logtype pretty print; Readers takes optional user timestamp format

### DIFF
--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -79,6 +79,7 @@ class Log:
             var_start: int = var_delim_match.start()
             logtype += self.encoded_logtype[pos:var_start].decode()
             msg += self.encoded_logtype[pos:var_start].decode()
+            pos = var_delim_match.end()
 
             var_delim: bytes = var_delim_match.group(0)
             var_str: str
@@ -100,7 +101,6 @@ class Log:
                 raise RuntimeError("Unknown delimiter")
 
             msg += var_str
-            pos = var_delim_match.end()
         logtype += self.encoded_logtype[pos:].decode()
         msg += self.encoded_logtype[pos:].decode()
         self.logtype = logtype


### PR DESCRIPTION
# Description
The pretty print logtype now shows the variable type (as `<int>`, `<float>`, or `<str>`) rather than only `<var>`.
The Readers can now take a timestamp format that will be used with `datetime.strftime`.

# Validation performed
Manually tested and verified on existing logs. Unit tests all passing.

