### PR TITLE
Fixes Timer threads to be daemons; Check the close timeout in unit tests

### DIFF
--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -251,6 +251,7 @@ class CLPLogLevelTimeout:
             self.hard_timeout_thread = Timer(
                 new_hard_timeout_ts / 1000 - time.time(), self.timeout
             )
+            self.hard_timeout_thread.setDaemon(True)
             self.hard_timeout_thread.start()
             self.next_hard_timeout_ts = new_hard_timeout_ts
 
@@ -271,6 +272,7 @@ class CLPLogLevelTimeout:
         if self.soft_timeout_thread:
             self.soft_timeout_thread.cancel()
         self.soft_timeout_thread = Timer(new_soft_timeout_ms / 1000 - time.time(), self.timeout)
+        self.soft_timeout_thread.setDaemon(True)
         self.soft_timeout_thread.start()
 
 


### PR DESCRIPTION
# Description
Timer threads not being daemons would prevent programs from exiting unless the handler was explicitly closed.
This fix sets them to be daemons and adds additional checking to the unit tests.

# Validation performed
All unit tests passing.

