### PR TITLE
Eof token decode

### DIFF
--- a/src/clp_logging/protocol.py
+++ b/src/clp_logging/protocol.py
@@ -91,7 +91,4 @@ SIZEOF: Dict[bytes, Tuple[int, bool]] = {
     TIMESTAMP_DELTA_BYTE: (SIZEOF_BYTE, True),
     TIMESTAMP_DELTA_SHORT: (SIZEOF_SHORT, True),
     TIMESTAMP_DELTA_INT: (SIZEOF_INT, True),
-    # This is used to handle distinguishing null bytes from flushing a
-    # zstandard frame and actual eof
-    EOF_CHAR: (SIZEOF_INT, False),
 }

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -273,9 +273,9 @@ class CLPBaseReader(metaclass=ABCMeta):
                 token_type, token, pos = CLPDecoder.decode_token(
                     self.view[offset : self.valid_buf_len]
                 )
-                if token_type == -1:  # Read more
+                if token_type == -1 or token_type == -5:  # Read more
                     break
-                elif token_type < -1:
+                elif token_type < 0:
                     raise RuntimeError(
                         f"Error decoding token: 0x{token.hex()}, type: {token_type}"
                     )

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -275,7 +275,6 @@ class CLPBaseReader(metaclass=ABCMeta):
                 )
                 if token_type < 0:
                     if token_type < -2:
-                        # Error occured when decoding the token.
                         raise RuntimeError(
                             f"Error decoding token: 0x{token.hex()}, type: {token_type}"
                         )

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -273,12 +273,14 @@ class CLPBaseReader(metaclass=ABCMeta):
                 token_type, token, pos = CLPDecoder.decode_token(
                     self.view[offset : self.valid_buf_len]
                 )
-                if token_type == -1 or token_type == -5:  # Read more
-                    break
-                elif token_type < 0:
-                    raise RuntimeError(
-                        f"Error decoding token: 0x{token.hex()}, type: {token_type}"
-                    )
+                if token_type < 0:
+                    if token_type < -2:
+                        # Error occured when decoding the token.
+                        raise RuntimeError(
+                            f"Error decoding token: 0x{token.hex()}, type: {token_type}"
+                        )
+                    else:  # Read more
+                        break
 
                 offset += pos
                 # This occurs when we have seen a null byte, but were able to


### PR DESCRIPTION
# References
When using the decode_token to process an uncompressed stream, it returns -1 when reaching the terminated null byte. No additional logic indicates the return can be the real EOF, as it always expects four magic zstd flush bytes appended.

# Description
Adds a unique return value (-2) to indicate decode_token has reached the end of the current buffer with a null byte.
Uses return values (< -2) to indicate other errors in token decoding.

# Validation performed
It doesn't change the original behavior as all unit tests passed.

