### PR TITLE
Fixes mistaken NULL/EOF Zstandard logic; Adds uncompressed Readers and unit tests

### DIFF
--- a/src/clp_logging/decoder.py
+++ b/src/clp_logging/decoder.py
@@ -150,7 +150,6 @@ class CLPDecoder:
                 if end >= src_len:
                     return -1, type_byte, end
                 return token_type, src[pos:end], end
-
         elif token_id == ID_LOGTYPE:
             logtype_size: int = int.from_bytes(src[pos:end], BYTE_ORDER, signed=signed)
             pos = end
@@ -158,9 +157,7 @@ class CLPDecoder:
             if end >= src_len:
                 return -1, type_byte, end
             return token_type, src[pos:end], end
-
         elif token_id == ID_TIMESTAMP:
             return token_type, src[pos:end], end
-
         else:
             return -2, type_byte, end

--- a/src/clp_logging/decoder.py
+++ b/src/clp_logging/decoder.py
@@ -115,6 +115,9 @@ class CLPDecoder:
         EOF_CHAR, -1 if `src` is exhausted before completing a token, or < -1
         for other errors.
         """
+        # We cannot directly get a single byte at pos with src[pos] as this
+        # will return an integer and we still need to do byte comparisons
+        # later.
         type_byte: memoryview = src[pos : pos + SIZEOF_BYTE]
         pos += SIZEOF_BYTE
         if type_byte == EOF_CHAR:

--- a/src/clp_logging/decoder.py
+++ b/src/clp_logging/decoder.py
@@ -84,7 +84,7 @@ class CLPDecoder:
             return None, -2
         pos += encoding_len
 
-        type_byte: bytes = view[pos : pos + 1]
+        type_byte: bytes = view[pos : pos + SIZEOF_BYTE]
         pos += SIZEOF_BYTE
         json_size: int
         if type_byte == METADATA_LEN_UBYTE:
@@ -132,6 +132,9 @@ class CLPDecoder:
         if end >= src_len:
             return -1, type_byte, end
 
+        # SIZEOF_BYTE can only ever be 1 to match the size of an element in a
+        # bytes-like python object. Therefore, we can get the integer value of
+        # type_byte by indexing it.
         token_type: int = type_byte[0]
         token_id: int = token_type & ID_MASK
         if token_id == ID_VAR:

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -52,9 +52,11 @@ def _init_timeinfo(fmt: Optional[str], tz: Optional[str]) -> Tuple[str, str]:
     if not tz:
         tzf = dateutil.tz.gettz()
         if tzf:
-            if tzf._filename == "/etc/localtime":
-                tzp = Path.resolve(Path(tzf._filename))
+            if tzf._filename == "/etc/localtime":  # type: ignore
+                tzp = Path.resolve(Path(tzf._filename))  # type: ignore
             tz = "/".join([tzp.parent.name, tzp.name])
+        else:
+            tz = "UCT"
     return fmt, tz
 
 
@@ -424,7 +426,7 @@ class CLPSockListener:
             ostream.write(EOF_CHAR)
 
             if enable_compression:
-                # Since we are not using context manager, the ostream should be 
+                # Since we are not using context manager, the ostream should be
                 # explicitly closed.
                 ostream.close()
         # tell _server to exit

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -36,14 +36,16 @@ WARN_PREFIX: str = " [WARN][clp_logging]"
 
 def _init_timeinfo(fmt: Optional[str], tz: Optional[str]) -> Tuple[str, str]:
     """
-    Set default timestamp format or timezone if not specified.
-    If no timezone is specified it will try to default to the system local
-    timezone. If that fails it will default to UTC.
-    In the future sanitization of user input should also go here.
-    Currently, timestamp format defaults to a format for the Java readers, due
+    Return the timestamp format and timezone (in TZID format) that should be
+    used. If not specified by the user, this function will choose default
+    values to use.
+    The timestamp format (`fmt`) defaults to a format for the Java readers, due
     to compatibility issues between language time libraries.
     (`datatime.isoformat` is always used for the timestamp format in python
     readers.)
+    The timzeone format (`tz`) first defaults to the system local timezone. If
+    that fails it will default to UTC.
+    In the future sanitization of user input should also go here.
 
     :param fmt: Timestamp format written in preamble to be used when generating
     the logs with a reader.

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -384,7 +384,8 @@ class CLPStreamReader(CLPBaseReader):
     def close(self) -> None:
         if self.zstream:
             self.zstream.close()  # type: ignore
-        self.stream.close()
+        else:
+            self.stream.close()
 
 
 class CLPFileReader(CLPStreamReader):

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -164,7 +164,17 @@ class CLPBaseReader(metaclass=ABCMeta):
         self.valid_buf_len = self.readinto_buf(0)
         if self.valid_buf_len <= 0:
             raise RuntimeError("readinto_buf for preamble failed")
-        self.metadata, self.pos = CLPDecoder.decode_preamble(self.view, 0)
+        try:
+            self.metadata, self.pos = CLPDecoder.decode_preamble(self.view, 0)
+        except Exception as e:
+            if len(self._buf) == self.valid_buf_len:
+                raise RuntimeError(
+                    "CLPDecoder.decode_preamble failed; CLPReader chunk_size likely too small."
+                    f" [self._buf/chunk_size({len(self._buf)}) == self.valid_buf_len"
+                    f"({self.valid_buf_len})]"
+                ) from e
+            else:
+                raise
         if self.metadata:
             self.last_timestamp_ms = int(self.metadata[METADATA_REFERENCE_TIMESTAMP_KEY])
             # We do not use the timestamp pattern from the preamble as it may
@@ -273,21 +283,15 @@ class CLPBaseReader(metaclass=ABCMeta):
                 token_type, token, pos = CLPDecoder.decode_token(
                     self.view[offset : self.valid_buf_len]
                 )
-                if token_type < 0:
-                    if token_type < -2:
-                        raise RuntimeError(
-                            f"Error decoding token: 0x{token.hex()}, type: {token_type}"
-                        )
-                    else:  # Read more
-                        break
-
+                if token_type == -1:
+                    break
+                elif token_type == ID_EOF:
+                    return 0
+                elif token_type < -1:
+                    raise RuntimeError(
+                        f"Error decoding token: 0x{token.hex()}, type: {token_type}"
+                    )
                 offset += pos
-                # This occurs when we have seen a null byte, but were able to
-                # read past it from the zstandard stream. This occurs when a
-                # zstandard frame was flushed. After we have incremented offset
-                # past the zstandard bytes we can continue to read tokens.
-                if token_type == ID_EOF:
-                    continue
 
                 if log:
                     self._store_token(log, token_type, token)
@@ -311,9 +315,7 @@ class CLPBaseReader(metaclass=ABCMeta):
             offset = 0
 
             ret: int = self.readinto_buf(valid)
-            if ret == 0 and token == EOF_CHAR:
-                return 0
-            elif ret < 0:
+            if ret < 0:
                 return -1
             self.valid_buf_len = valid + ret
 
@@ -354,24 +356,34 @@ class CLPStreamReader(CLPBaseReader):
     """
 
     def __init__(
-        self, stream: IO[bytes], timestamp_format: Optional[str] = None, chunk_size: int = 4096
+        self,
+        stream: IO[bytes],
+        timestamp_format: Optional[str] = None,
+        chunk_size: int = 4096,
+        enable_compression: bool = True,
     ) -> None:
         super().__init__(timestamp_format, chunk_size)
         self.stream: IO[bytes] = stream
-        self.dctx: ZstdDecompressor = ZstdDecompressor()
-        self.zstream: ZstdDecompressionReader = self.dctx.stream_reader(
-            self.stream, read_across_frames=True
-        )
+        self.dctx: Optional[ZstdDecompressor] = None
+        self.zstream: Optional[ZstdDecompressionReader] = None
+        if enable_compression:
+            self.dctx = ZstdDecompressor()
+            self.zstream = self.dctx.stream_reader(self.stream, read_across_frames=True)
 
     def readinto_buf(self, offset: int) -> int:
         """
-        Use Zstandard to decompress the CLP IR stream.
+        Read the CLP IR stream directly or through Zstandard decompression.
         :return: Bytes read (0 for EOF), < 0 on error
         """
-        return self.zstream.readinto(self.view[offset:])
+        if self.zstream:
+            return self.zstream.readinto(self.view[offset:])
+        else:
+            # see https://github.com/python/typing/issues/659
+            return self.stream.readinto(self.view[offset:])  # type: ignore
 
     def close(self) -> None:
-        self.zstream.close()
+        if self.zstream:
+            self.zstream.close()  # type: ignore
         self.stream.close()
 
 
@@ -379,10 +391,14 @@ class CLPFileReader(CLPStreamReader):
     """Wrapper class that calls `open` for convenience."""
 
     def __init__(
-        self, fpath: Path, timestamp_format: Optional[str] = None, chunk_size: int = 4096
+        self,
+        fpath: Path,
+        timestamp_format: Optional[str] = None,
+        chunk_size: int = 4096,
+        enable_compression: bool = True,
     ) -> None:
         self.path: Path = fpath
-        super().__init__(open(fpath, "rb"), timestamp_format, chunk_size)
+        super().__init__(open(fpath, "rb"), timestamp_format, chunk_size, enable_compression)
 
     def dump(self) -> None:
         for log in self:

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -283,10 +283,10 @@ class CLPBaseReader(metaclass=ABCMeta):
                 token_type, token, pos = CLPDecoder.decode_token(
                     self.view[offset : self.valid_buf_len]
                 )
-                if token_type == -1:
-                    break
-                elif token_type == ID_EOF:
+                if token_type == ID_EOF:
                     return 0
+                elif token_type == -1:
+                    break
                 elif token_type < -1:
                     raise RuntimeError(
                         f"Error decoding token: 0x{token.hex()}, type: {token_type}"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -309,7 +309,7 @@ class TestCLPLogLevelTimeoutBase(TestCLPBase):
         def timeout_fn() -> None:
             nonlocal timeout_ts
             nonlocal timeout_count
-            timeout_ts[timeout_count.value] = time.time()  # type: ignore
+            timeout_ts[timeout_count.value] = c_double(time.time())
             timeout_count.value += 1
 
         self.loglevel_timeout = CLPLogLevelTimeout(timeout_fn, hard_deltas, soft_deltas)


### PR DESCRIPTION
# References
https://github.com/y-scope/clp-loglib-py/pull/18 Mistakenly adds logic to handle a case thought to be a bug that does not actually occur.

# Description
Removes the decoding and reading logic surrounding NULL bytes incorrectly thought to be from Zstandard. This simplifies the code as a NULL byte will only be seen as a token at the end of an IR stream.

Adds an `enable_compression` flag to Readers (matching the Handler flag) that defaults to `True`. When set to false a Reader will decode an uncompressed IR stream.
Unit testing code updated and refactored to allow for all tests to also be ran with uncompressed IR.

# Validation performed
All unit tests (new and old) passing.
@LinZhihao-723 manually tested their stream reader to read and split each stream, ensuring correct decompression.

