### PR TITLE
Add docformatter to format docstrings; Clarify error-checking and formatting instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,20 +227,20 @@ result in a test reporting a false positive error.
 
 ## Contributing
 
-Before submitting a pull request, run the following error-checking and formatting tools (found in
-[requirements-dev.txt](requirements-dev.txt)):
+Before submitting a pull request, run the following error-checking and
+formatting tools (found in [requirements-dev.txt](requirements-dev.txt)):
 
-* [mypy][3]: `mypy src`
-  * mypy checks for typing errors. You should resolve all typing errors or if an error cannot be 
-    resolved (e.g., it's due to a third-party library), you should add a comment 
-    `# type: ignore` to [silence][4] the error.
-* [docformatter][5]: `docformatter -i src`
+* [mypy][3]: `mypy src tests`
+  * mypy checks for typing errors. You should resolve all typing errors or if an
+    error cannot be resolved (e.g., it's due to a third-party library), you
+    should add a comment `# type: ignore` to [silence][4] the error.
+* [docformatter][5]: `docformatter -i src tests`
   * This formats docstrings. You should review and add any changes to your PR.
-* [Black][6]: `black src`
-  * This formats the code according to Black's code-style rules. You should review and add any
-    changes to your PR.
+* [Black][6]: `black src tests`
+  * This formats the code according to Black's code-style rules. You should
+    review and add any changes to your PR.
 
-Note that `docformatter` should be run before `black` to give Black the [last 
+Note that `docformatter` should be run before `black` to give Black the [last
 word][7].
 
 [0]: https://github.com/y-scope/clp

--- a/README.md
+++ b/README.md
@@ -227,10 +227,27 @@ result in a test reporting a false positive error.
 
 ## Contributing
 
-Ensure to run `mypy` and `black` (found in
-[requirements-dev.txt](requirements-dev.txt)) during development to ensure
-smooth pull requests.
+Before submitting a pull request, run the following error-checking and formatting tools (found in
+[requirements-dev.txt](requirements-dev.txt)):
+
+* [mypy][3]: `mypy src`
+  * mypy checks for typing errors. You should resolve all typing errors or if an error cannot be 
+    resolved (e.g., it's due to a third-party library), you should add a comment 
+    `# type: ignore` to [silence][4] the error.
+* [docformatter][5]: `docformatter -i src`
+  * This formats docstrings. You should review and add any changes to your PR.
+* [Black][6]: `black src`
+  * This formats the code according to Black's code-style rules. You should review and add any
+    changes to your PR.
+
+Note that `docformatter` should be run before `black` to give Black the [last 
+word][7].
 
 [0]: https://github.com/y-scope/clp
 [1]: https://www.uber.com/blog/reducing-logging-cost-by-two-orders-of-magnitude-using-clp/
 [2]: https://github.com/y-scope/yscope-log-viewer
+[3]: https://mypy.readthedocs.io/en/stable/index.html
+[4]: https://mypy.readthedocs.io/en/stable/common_issues.html#spurious-errors-and-locally-silencing-the-checker
+[5]: https://docformatter.readthedocs.io/en/latest/
+[6]: https://black.readthedocs.io/en/stable/index.html
+[7]: https://docformatter.readthedocs.io/en/latest/faq.html#interaction-with-black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ classifiers = [
 strict = true
 pretty = true
 
+[tool.docformatter]
+make-summary-multi-line = true
+pre-summary-newline = true
+recursive = true
+wrap-summaries = 80
+wrap-descriptions = 80
+
 [tool.black]
 line-length = 99
 target-version = ["py311"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 black==22.10.0
 build==0.8.0
 click==8.1.3
+docformatter==1.5.1
 mypy==0.982
 mypy-extensions==0.4.3
 packaging==21.3

--- a/src/clp_logging/decoder.py
+++ b/src/clp_logging/decoder.py
@@ -24,6 +24,7 @@ from clp_logging.protocol import (
 class CLPDecoder:
     """
     Namespace for all CLP decoding functions.
+
     Functions decode bytes extracting CLP tokens and translate them to their
     true type and value.
     """
@@ -39,6 +40,7 @@ class CLPDecoder:
         """
         See `CLPEncoder.encode_float` for detailed breakdown of CLP float
         encoding.
+
         :return: Tuple of `float` and `str` value of token
         """
         backing_int: int = int.from_bytes(token, BYTE_ORDER)
@@ -69,6 +71,7 @@ class CLPDecoder:
     def decode_preamble(src: bytes, pos: int) -> Tuple[Optional[Metadata], int]:
         """
         Decode `src` start at `pos` extracting the preamble/metadata.
+
         :return: On success returns the metadata and the index read up to in
         `src` (including `pos`). On error returns None and negative int based
         on error: -1 if magic number mismatch, -2 if metadata not in json
@@ -103,10 +106,10 @@ class CLPDecoder:
     def decode_token(src: memoryview, pos: int = 0) -> Tuple[int, bytes, int]:
         """
         Decode `src` start at `pos` extracting the next token.
+
         Note, we can use negative values despite `token_type` being an `int` as
         the integer value of an individual byte is restricted to [0:256) (see
-        `bytes`). Therefore `token_type` (`type_byte[0]`) can never be
-        negative.
+        `bytes`). Therefore `token_type` (`type_byte[0]`) can never be negative.
 
         :param src: Bytes to decode
         :param pos: The position in `src` to begin decoding from

--- a/src/clp_logging/encoder.py
+++ b/src/clp_logging/encoder.py
@@ -62,6 +62,7 @@ FLOAT_VAR_TOKEN_MAX_BYTES: int = 9
 class CLPEncoder:
     """
     Namespace for all CLP encoding functions.
+
     Functions encode bytes from the log record to create a CLP message.
     """
 
@@ -69,6 +70,7 @@ class CLPEncoder:
     def emit_preamble(timestamp: int, timestamp_format: str, timezone: str) -> bytearray:
         """
         Create the encoded CLP preamble for a stream of encoded log messages.
+
         :param timestamp: Reference timestamp used to calculate deltas emitted
         with each message.
         :param timestamp_format: Timestamp format to be use when generating the
@@ -148,6 +150,7 @@ class CLPEncoder:
     def encode_float(token: bytes, clp_msg: bytearray) -> bool:
         """
         Encode `token` to float and append to `clp_msg`
+
         :param token: Guaranteed to contain: at least one digit (0-9) and at
         least one period (decimal point). However, could be malformed with
         multiple periods or negative signs.
@@ -228,6 +231,7 @@ class CLPEncoder:
     def emit_token(token_m: Match[bytes], clp_msg: bytearray) -> bytes:
         """
         Encode `token_m` appending it to `clp_msg` if it is a variable.
+
         :return: If the token was a variable returns the delimiter to append to
         logtype, otherwise returns the static text to append to the logtype.
         """
@@ -266,8 +270,9 @@ class CLPEncoder:
     @staticmethod
     def encode_timestamp(last_timestamp_ms: int, buf: bytearray) -> int:
         """
-        Encode the timestamp delta between `last_timestamp_ms` and the
-        current `time()` into `buf`
+        Encode the timestamp delta between `last_timestamp_ms` and the current
+        `time()` into `buf`
+
         :raises NotImplementedError: If unsupported timestamp delta size
         :return: The current timestamp (from `time.time()`)
         """

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -38,6 +38,7 @@ class Log:
     classes inheriting from `CLPBaseReader`. A `Log` will only contain the
     decoded fields after `_decode` has been called. `Log` objects should be
     created using reader iterators to ensure they are valid.
+
     :param timestamp_ms: Time in ms since Unix epoch
     :param encoded_logtype: Encoded logtype
     :param encoded_variables: Encoded and untyped variables
@@ -64,6 +65,7 @@ class Log:
         """
         Populate the `variables`, `msg`, and `formatted_msg` fields by decoding
         the encoded `encoded_logtype and `encoded_variables`.
+
         :param timestamp_format: If provided, used by `datetime.strftime` to
         format the timestamp. If `None` then `datetime.isoformat` is used.
         :param timezone: Timezone to use when creating the timestamp from Unix
@@ -120,6 +122,7 @@ class CLPBaseReader(metaclass=ABCMeta):
     Abstract reader class used to build readers/decoders for CLP IR/"logs"
     produced by handlers/encoders. `readinto_buf` and `close` must be
     implemented by derived readers to correctly managed the underlying `_buf`.
+
     :param _buf: Underlying `bytearray` used to read the CLP IR
     :param view: `memoryview` of `bytearray` to allow convenient slicing
     :param metadata: Metadata from CLP IR header
@@ -133,7 +136,8 @@ class CLPBaseReader(metaclass=ABCMeta):
 
     def __init__(self, timestamp_format: Optional[str], chunk_size: int) -> None:
         """
-        Constructor
+        Constructor.
+
         :param timestamp_format: Format optionally provided by user to format
         timestamps from epoch time.
         :param chunk_size: initial size of `_buf` for reading
@@ -149,12 +153,13 @@ class CLPBaseReader(metaclass=ABCMeta):
 
     def read_preamble(self) -> int:
         """
-        Try to decode the preamble and populate `metadata`. If the metadata
-        is already read it instantly returns. We avoid calling
+        Try to decode the preamble and populate `metadata`. If the metadata is
+        already read it instantly returns. We avoid calling
         `CLPDecoder.decode_preamble` in `__init_` as `readinto_buf` may block,
         putting unexpected constraints on the user code. For example, any
         stream, file, etc. would need to be readable on a reader's construction
         rather than when the user actually begins to iterate the logs.
+
         :raises RuntimeError: If `readinto_buf` error or already EOF before
         preamble
         :return: Position in `view`
@@ -188,6 +193,7 @@ class CLPBaseReader(metaclass=ABCMeta):
     def readinto_buf(self, offset: int) -> int:
         """
         Abstract method to populate the underlying `_buf`.
+
         :return: Bytes read (0 for EOF), < 0 on error
         """
         raise NotImplementedError("Readinto_buf must be implemented by derived readers")
@@ -226,6 +232,7 @@ class CLPBaseReader(metaclass=ABCMeta):
     def skip_nlogs(self, n: int = 1) -> int:
         """
         Skip the next `n` log records/events.
+
         :return: Number of logs skipped
         """
         if self.read_preamble() <= 0:
@@ -242,7 +249,9 @@ class CLPBaseReader(metaclass=ABCMeta):
 
     def skip_to_time(self, time_ms: int) -> int:
         """
-        Skip all logs with Unix epoch timestamp before `time_ms`.  After
+        Skip all logs with Unix epoch timestamp before `time_ms`.
+
+        After
         being called the next `Log` returned by the reader (e.g. calling
         `__next__`) will return the first log where `Log.timestamp_ms` >=
         `time_ms`
@@ -267,10 +276,11 @@ class CLPBaseReader(metaclass=ABCMeta):
 
     def _readinto(self, offset: int, log: Optional[Log]) -> int:
         """
-        Read and decode from `view` into `log`. `view` is expected to be
-        past the preamble, so `read_preamble` must have been called prior.
-        `pos` is only updated when `_buf` and `view` are updated. This allows
-        callers to re-read the contents inside `_buf` and `view` if desired.
+        Read and decode from `view` into `log`. `view` is expected to be past
+        the preamble, so `read_preamble` must have been called prior. `pos` is
+        only updated when `_buf` and `view` are updated. This allows callers to
+        re-read the contents inside `_buf` and `view` if desired.
+
         :param offset: Position in `view` to begin decoding from
         :param log: `Log` object to store tokens in, if None tokens are dropped
         without further processing and storing
@@ -326,6 +336,7 @@ class CLPBaseReader(metaclass=ABCMeta):
         `token_type`. Bytes in the raw log that match special encoding bytes
         were escaped, so we must unescape any set of bytes copied directly from
         `_buf` (dict variables and logtype).
+
         :raises RuntimeError: If `token_type & ID_MASK` is invalid
         """
         token_id: int = token_type & ID_MASK
@@ -350,7 +361,8 @@ class CLPBaseReader(metaclass=ABCMeta):
 
 class CLPStreamReader(CLPBaseReader):
     """
-    Simple stream reader that will decompress the Zstandard stream
+    Simple stream reader that will decompress the Zstandard stream.
+
     :param timestamp_format: Format optionally provided by user to format
     timestamps from epoch time.
     :param chunk_size: initial size of `CLPBaseReader._buf` for reading
@@ -374,6 +386,7 @@ class CLPStreamReader(CLPBaseReader):
     def readinto_buf(self, offset: int) -> int:
         """
         Read the CLP IR stream directly or through Zstandard decompression.
+
         :return: Bytes read (0 for EOF), < 0 on error
         """
         if self.zstream:
@@ -390,7 +403,9 @@ class CLPStreamReader(CLPBaseReader):
 
 
 class CLPFileReader(CLPStreamReader):
-    """Wrapper class that calls `open` for convenience."""
+    """
+    Wrapper class that calls `open` for convenience.
+    """
 
     def __init__(
         self,
@@ -409,11 +424,12 @@ class CLPFileReader(CLPStreamReader):
 
 class _CLPSegmentStreamingReader:
     """
-    Private reader class used to read stream segments for CLP IR/"logs"
-    produced by handlers/encoders. The members in this class are used to
-    maintain a single operation for segment reading/streaming. The instance
-    of this class should not be reused, meaning that for each segment streaming,
-    there should be an individual instance of this class associated.
+    Private reader class used to read stream segments for CLP IR/"logs" produced
+    by handlers/encoders. The members in this class are used to maintain a
+    single operation for segment reading/streaming. The instance of this class
+    should not be reused, meaning that for each segment streaming, there should
+    be an individual instance of this class associated.
+
     :param istream: input stream to read from. It should be an abstracted
     uncompressed seekable IR stream, and it should have the method `readinto`
     :param ostream: output stream to write into. It should be an abstracted
@@ -446,7 +462,8 @@ class _CLPSegmentStreamingReader:
         chunk_size: int = 4096,
     ) -> None:
         """
-        Constructor
+        Constructor.
+
         :param istream: seekable uncompressed input stream
         :param ostream: uncompressed output stream
         :param offset: position to start reading from
@@ -472,6 +489,7 @@ class _CLPSegmentStreamingReader:
     def readinto_buf(self, offset: int) -> int:
         """
         Populate the underlying `_buf`.
+
         :return: Bytes read (0 for EOF), < 0 on error
         """
         bytes_read: int = self.istream.readinto(self.view[offset:])
@@ -481,7 +499,9 @@ class _CLPSegmentStreamingReader:
     def init_preamble(self) -> Optional[bytearray]:
         """
         Initialize the CLP IR header for the coming read, and initialize
-        `last_timestamp_ms`. If metadata is not provided, it will attempt to
+        `last_timestamp_ms`.
+
+        If metadata is not provided, it will attempt to
         parse the header from `_buf` and set `init_pos`.
         :return: CLP IR header represented as a byte array.
         """
@@ -512,6 +532,7 @@ class _CLPSegmentStreamingReader:
         Use the latest processed real timestamp to construct a legal CLP IR
         metadata, which can be used to resume read from current position in
         later segment streaming.
+
         However, if the EOF is reached, None should be returned since the
         terminated read should not be resumed.
         :return: CLP IR metadata header.
@@ -525,6 +546,7 @@ class _CLPSegmentStreamingReader:
         """
         Check if the output stream has enough space reserved to write
         `len_to_write` of bytes.
+
         :return: True if the ostream has no space to write.
         """
         return (
@@ -534,7 +556,9 @@ class _CLPSegmentStreamingReader:
 
     def stream_ir_segment(self) -> Tuple[int, Optional[Metadata]]:
         """
-        Streaming from istream to ostream, starting from `offset`. It stops
+        Streaming from istream to ostream, starting from `offset`.
+
+        It stops
         either the istream is consumed, or the number of bytes written into the
         ostream exceeds `max_bytes_to_write`. This method will gaurantee to read
         till the last valid log message from the IR.
@@ -650,11 +674,12 @@ class _CLPSegmentStreamingReader:
 class CLPSegmentStreaming:
     """
     Wrapper for _CLPSegmentStreamingReader.
+
     As explained in _CLPSegmentStreamingReader, its members are designed to
-    maintain a single read operation and thus not reuseable.
-    This class encapsulate the actual stream reader class and provide a static
-    method to ensure that each individual read operation will have its own
-    instance of _CLPSegmentStreamingReader.
+    maintain a single read operation and thus not reusable. This class
+    encapsulates the actual stream reader class and provides a static method to
+    ensure that each individual read operation will have its own instance of
+    _CLPSegmentStreamingReader.
     """
 
     @staticmethod

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,9 +5,11 @@ import unittest
 
 
 def add_tests(suite: unittest.TestSuite, loader: unittest.TestLoader, test_class: type) -> None:
-    """Recursively collect tests from concrete classes. Although TestCLPBase*
+    """
+    Recursively collect tests from concrete classes. Although TestCLPBase*
     classes are functionally abstract to the user we cannot properly make them
     abstract as `unittest` will still create instances of these classes.
+
     :param suite: test suite to add found tests to
     :param loader: load test from `unittest.TestCase` class
     :param test_class: current class to search for tests in

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -48,8 +48,8 @@ LOG_DIR: Path = Path("unittest-logs")
 class DtStreamHandler(logging.StreamHandler):  # type: ignore
     """
     `logging` handler using `datetime` for the timestamp rather than `time`
-    (used internally by `logging`). Necessary for correct comparison with CLP
-    log handlers.
+    (used internally by `logging`), so we can perform correct comparison with
+    CLP log handlers.
     """
 
     def __init__(self, stream: IO[str]) -> None:
@@ -80,12 +80,14 @@ class DtFileHandler(DtStreamHandler):
 
 class TestCLPBase(unittest.TestCase):
     """
-    Functionally abstract as we use `load_tests` to avoid adding
-    `TestCLPBase` itself to the test suite. This allows us to share tests
-    between different handlers.
-    However, we cannot mark it as abstract as `unittest` will still `__init__`
-    an instance before `load_tests` is run (and will error out if any method
-    is marked abstract).
+    Functionally abstract base class for testing handlers, etc.
+
+    Functionally abstract as we use `load_tests` to avoid adding `TestCLPBase`
+    itself to the test suite. This allows us to share tests between different
+    handlers. However, we cannot mark it as abstract as `unittest` will still
+    `__init__` an instance before `load_tests` is run (and will error out if any
+    method is marked abstract).
+
     Non-base classes have shortened names to avoid errors with socket name
     length.
     """
@@ -552,10 +554,12 @@ class TestCLPStream_LLT_RAW(TestCLPLogLevelTimeoutBase):
 
 class TestCLPSegmentStreamingBase(unittest.TestCase):
     """
+    Functionally abstract base class for testing segment streaming.
+
     Similar to `TestCLPBase`. Functionally abstract as we use `load_tests` to
     avoid adding `TestCLPSegmentStreamingBase` itself to the test suite. This
-    allows us to share tests between different settings when test against
-    IR segment streaming.
+    allows us to share tests between different settings when test against IR
+    segment streaming.
     """
 
     clp_handler: CLPBaseHandler


### PR DESCRIPTION
<!-- # References -->
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

* Added the tool `docformatter` to automatically format docstrings according to our line length style requirements.
* Ran the tool and made minor modifications to its output to fit with the previous docstring formatting.
* Added clearer instructions for running the error-checking and formatting tools before contributions.

<!-- # Validation performed -->
<!-- What tests and validation you performed on the change -->
