### PR TITLE
Fix typos and mypy errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,11 @@ result in a test reporting a false positive error.
 
 1. Create and enter a virtual environment:
    `python -m venv venv; .  ./venv/bin/activate`
-2. Install:
+2. Install development dependencies:
+   `pip install -r requirements-dev.txt`
+3. Install:
    `pip install dist/clp_logging-*-py3-none-any.whl` or `pip install -e .`
-3. Run unittest:
+4. Run unittest:
    `python -m unittest -bv`
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ with CLPFileReader(Path("example.clp.zst")) as clp_reader:
 
 ### CLPSegmentStreaming
 
-* Classes inheriting CLPBaseReader are only capable of reading a single CLP IR stream from start to finish. This is required as to know the timestamp of an individual log, the starting timestamp (from the IR stream preamble) and all timestamp deltas up to that log must be known. In scenarios where a IR stream is periodically uploaded in chunks, users would need to either continuously read the entire stream or re-read the entire stream from the start.
+* Classes that inherit from CLPBaseReader can only read a single CLP IR stream from start to finish. This is necessary because, to determine the timestamp of an individual log, the starting timestamp (from the IR stream preamble) and all timestamp deltas up to that log must be known. In scenarios where an IR stream is periodically uploaded in chunks, users would need to either continuously read the entire stream or re-read the entire stream from the start.
 * The CLPSegmentStreaming class has the ability to take an input IR stream and segment it, outputting multiple independent IR streams. This makes it possible to read arbitrary segments of the original input IR stream without needing to decode it from the start.
-* In technical terms, the segment streaming reader allows the read operation to start from a non-zero offset, and streams the legal encoded logs from one stream to another.
-* Each read call will return an encoded metadata which can be used to resume from the current call.S
+* In technical terms, the segment streaming reader allows the read operation to start from a non-zero offset and streams the legally encoded logs from one stream to another.
+* Each read call will return encoded metadata that can be used to resume from the current call.
 
 #### Example code: CLPSegmentStreaming
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ with CLPFileReader(Path("example.clp.zst")) as clp_reader:
 
 ### CLPSegmentStreaming
 
-* Segment streaming reader allows the read operation to start from a non-zero offset, and streams the legal encoded logs from one stream to another.
-* Each read call will return an encoded metadata which can be used to resume from the current call.
+* Classes inheriting CLPBaseReader are only capable of reading a single CLP IR stream from start to finish. This is required as to know the timestamp of an individual log, the starting timestamp (from the IR stream preamble) and all timestamp deltas up to that log must be known. In scenarios where a IR stream is periodically uploaded in chunks, users would need to either continuously read the entire stream or re-read the entire stream from the start.
+* The CLPSegmentStreaming class has the ability to take an input IR stream and segment it, outputting multiple independent IR streams. This makes it possible to read arbitrary segments of the original input IR stream without needing to decode it from the start.
+* In technical terms, the segment streaming reader allows the read operation to start from a non-zero offset, and streams the legal encoded logs from one stream to another.
+* Each read call will return an encoded metadata which can be used to resume from the current call.S
 
 #### Example code: CLPSegmentStreaming
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ mypy-extensions==0.4.3
 packaging==21.3
 pathspec==0.10.1
 pep517==0.13.0
-pkg_resources==0.0.0
 platformdirs==2.5.2
 pyparsing==3.0.9
 python-dateutil==2.8.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pkg_resources==0.0.0
 platformdirs==2.5.2
 pyparsing==3.0.9
 python-dateutil==2.8.2
+smart_open==6.3.0
 six==1.16.0
 tomli==2.0.1
 types-python-dateutil==2.8.19.2

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -588,7 +588,7 @@ class _CLPSegmentStreamingReader:
                     self.eof_reached = True
                     break  # Reach the end of stream
                 elif token_type == -1:
-                    break  # Pupolate the buffer and decode again
+                    break  # Populate the buffer and decode again
                 elif token_type < -1:
                     raise RuntimeError(
                         f"Error decoding token: 0x{token.hex()}, type: {token_type}"
@@ -648,12 +648,12 @@ class _CLPSegmentStreamingReader:
 
 class CLPSegmentStreaming:
     """
-    Wrapper for __CLPSegmentStreamingReader.
-    As explained in __CLPSegmentStreamingReader, its members are designed to
+    Wrapper for _CLPSegmentStreamingReader.
+    As explained in _CLPSegmentStreamingReader, its members are designed to
     maintain a single read operation and thus not reuseable.
     This class encapsulate the actual stream reader class and provide a static
     method to ensure that each individual read operation will have its own
-    instance of __CLPSegmentStreamingReader.
+    instance of _CLPSegmentStreamingReader.
     """
 
     @staticmethod

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -474,7 +474,8 @@ class _CLPSegmentStreamingReader:
         Populate the underlying `_buf`.
         :return: Bytes read (0 for EOF), < 0 on error
         """
-        bytes_read: int = self.istream.readinto(self.view[offset:])
+        # see https://github.com/python/typing/issues/659
+        bytes_read: int = self.istream.readinto(self.view[offset:])  # type:ignore
         self.total_bytes_read += bytes_read
         return bytes_read
 
@@ -518,6 +519,7 @@ class _CLPSegmentStreamingReader:
         """
         if self.eof_reached:
             return None
+        assert self.metadata is not None
         self.metadata[METADATA_REFERENCE_TIMESTAMP_KEY] = str(self.last_timestamp_ms)
         return self.metadata
 
@@ -528,7 +530,7 @@ class _CLPSegmentStreamingReader:
         :return: True if the ostream has no space to write.
         """
         return (
-            self.max_bytes_to_write != None
+            self.max_bytes_to_write is not None
             and (self.total_bytes_written + len_to_write + 1) > self.max_bytes_to_write
         )
 
@@ -556,7 +558,8 @@ class _CLPSegmentStreamingReader:
                 )
             self.istream.seek(self.offset)
 
-        bytes_read: int = self.readinto_buf(0)
+        bytes_read: int
+        bytes_read = self.readinto_buf(0)
         if bytes_read == 0:
             return 0, None
         elif bytes_read < 0:
@@ -575,6 +578,7 @@ class _CLPSegmentStreamingReader:
             raise RuntimeError("Failed to write into output stream.")
         self.total_bytes_written += bytes_written
 
+        bytes_consumed: int
         offset: int = self.init_pos
         log_buf: bytearray = bytearray(0)
         while True:
@@ -601,7 +605,7 @@ class _CLPSegmentStreamingReader:
                 if ID_TIMESTAMP == token_id:
                     log_length: int = len(log_buf)
                     if self.ostream_out_of_write_space(log_length):
-                        bytes_consumed: int = (
+                        bytes_consumed = (
                             self.total_bytes_read - log_length - (self.valid_buf_len - offset)
                         )
                         self.ostream.write(EOF_CHAR)
@@ -633,12 +637,12 @@ class _CLPSegmentStreamingReader:
                 self._buf = tmp
                 self.view = memoryview(self._buf)
 
-            bytes_read: int = self.readinto_buf(valid)
+            bytes_read = self.readinto_buf(valid)
             if bytes_read == 0:
                 # No more to read. This is the end of the current segment.
                 self.ostream.write(EOF_CHAR)
                 # Log in the current buffer is not written into ostream.
-                bytes_consumed: int = self.total_bytes_read - len(log_buf) - valid
+                bytes_consumed = self.total_bytes_read - len(log_buf) - valid
                 return bytes_consumed, self.generate_return_metadata()
             elif bytes_read < 0:
                 raise RuntimeError("Failed to read from input stream.")

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -604,6 +604,7 @@ class _CLPSegmentStreamingReader:
                         bytes_consumed: int = (
                             self.total_bytes_read - log_length - (self.valid_buf_len - offset)
                         )
+                        self.ostream.write(EOF_CHAR)
                         return bytes_consumed, self.generate_return_metadata()
                     # Increment the last recorded timestamp
                     self.last_timestamp_ms += int.from_bytes(token, BYTE_ORDER, signed=True)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 from typing import Iterable, Optional, Union
 
-from tests.test_handlers import TestCLPBase
+from tests.test_handlers import TestCLPBase, TestCLPSegmentStreamingBase
 import unittest
 
 
@@ -29,4 +29,8 @@ def load_tests(
 
     for test_class in TestCLPBase.__subclasses__():
         add_tests(suite, loader, test_class)
+    
+    for test_class in TestCLPSegmentStreamingBase.__subclasses__():
+        add_tests(suite, loader, test_class)
+        
     return suite

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,8 +29,8 @@ def load_tests(
 
     for test_class in TestCLPBase.__subclasses__():
         add_tests(suite, loader, test_class)
-    
+
     for test_class in TestCLPSegmentStreamingBase.__subclasses__():
         add_tests(suite, loader, test_class)
-        
+
     return suite

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,7 +32,7 @@ def load_tests(
     for test_class in TestCLPBase.__subclasses__():
         add_tests(suite, loader, test_class)
 
-    for test_class in TestCLPSegmentStreamingBase.__subclasses__():
-        add_tests(suite, loader, test_class)
+    for seg_test_class in TestCLPSegmentStreamingBase.__subclasses__():
+        add_tests(suite, loader, seg_test_class)
 
     return suite

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,8 +6,10 @@ import unittest
 from datetime import datetime, timedelta, tzinfo
 from math import floor
 from multiprocessing.sharedctypes import Array, Value, Synchronized, SynchronizedArray
+from smart_open import open, register_compressor
 from pathlib import Path
 from typing import cast, ClassVar, Dict, IO, List, Optional
+from zstandard import ZstdCompressor, ZstdDecompressor
 
 import dateutil.parser
 
@@ -20,7 +22,22 @@ from clp_logging.handlers import (
     DEFAULT_LOG_FORMAT,
     WARN_PREFIX,
 )
+from clp_logging.protocol import Metadata
 from clp_logging.readers import CLPFileReader
+from clp_logging.readers import CLPSegmentStreaming
+
+def _zstd_comppressions_handler(file_obj, mode):
+    if "wb" == mode:
+        cctx = ZstdCompressor()
+        return cctx.stream_writer(file_obj)
+    elif "rb" == mode:
+        dctx = ZstdDecompressor()
+        return dctx.stream_reader(file_obj)
+    else:
+        raise RuntimeError(f"Zstd handler: Unexpected Mode {mode}")
+    
+# Register .zst with zstandard library compressor
+register_compressor(".zst", _zstd_comppressions_handler)
 
 LOG_DIR: Path = Path("unittest-logs")
 
@@ -529,7 +546,146 @@ class TestCLPStream_LLT_RAW(TestCLPLogLevelTimeoutBase):
             self.clp_log_path, loglevel_timeout=self.loglevel_timeout, enable_compression=False
         )
         self.setup_logging()
+        
 
+class TestCLPSegmentStreamingBase(unittest.TestCase):
+    """
+    Similar to `TestCLPBase`. Functionally abstract as we use `load_tests` to 
+    avoid adding `TestCLPSegmentStreamingBase` itself to the test suite. This 
+    allows us to share tests between different settings when test against 
+    IR segment streaming.
+    """
+    
+    clp_handler: CLPBaseHandler
+    clp_log_path: Path
+    segment_path_list: List[Path]
+    segment_idx: int
+    logger: logging.Logger
+    # Configurable:
+    enable_compression: bool
+    segment_size: int
+    
+    # override
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not LOG_DIR.exists():
+            LOG_DIR.mkdir(parents=True, exist_ok=True)
+        assert LOG_DIR.is_dir()
+        
+    # override
+    def setUp(self) -> None:
+        if self.enable_compression:
+            self.clp_log_path: Path = LOG_DIR / Path(f"{self.id()}.clp.zst")
+        else:
+            self.clp_log_path: Path = LOG_DIR / Path(f"{self.id()}.clp")
+        if self.clp_log_path.exists():
+            self.clp_log_path.unlink()
+        self.segment_path_list: List[Path] = []
+        self.segment_idx = 0
+        
+    def generate_segments(self) -> None:
+        meta: Metadata = None
+        offset: int = 0
+        while True:
+            segment_path: Path
+            if self.enable_compression:
+                segment_path: Path = LOG_DIR / Path(f"{self.id()}_seg_{self.segment_idx}.clp.zst")
+            else:
+                segment_path: Path = LOG_DIR / Path(f"{self.id()}_seg_{self.segment_idx}.clp")
+            if segment_path.exists():
+                segment_path.unlink()
+            bytes_read: int
+            with open(self.clp_log_path, "rb") as fin, open(segment_path, "wb") as fout:
+                bytes_read, meta = CLPSegmentStreaming.read(
+                    fin, 
+                    fout, 
+                    offset=offset, 
+                    max_bytes_to_write=self.segment_size,
+                    metadata=meta
+                )
+                offset += bytes_read
+                self.segment_idx += 1
+            self.segment_path_list.append(segment_path)
+            if meta == None or bytes_read == 0:
+                break
+            
+    def close(self) -> None:
+        logging.shutdown()
+        self.logger.removeHandler(self.clp_handler)
+    
+    def read_clp(self) -> List[str]:
+        with CLPFileReader(self.clp_log_path, enable_compression=self.enable_compression) as logf:
+            return [log.formatted_msg for log in logf]
+        
+    def read_segments(self) -> List[str]:
+        logs: List[str] = []
+        for segment_path in self.segment_path_list:
+            with CLPFileReader(segment_path, enable_compression=self.enable_compression) as logf:
+                logs.extend([log.formatted_msg for log in logf])
+        return logs
+    
+    def compare_all_logs(self) -> None:
+        self.close()
+        self.generate_segments()
+        clp_logs: List[str] = self.read_clp()
+        segment_logs: List[str] = self.read_segments()
+        self.compare_logs(clp_logs, segment_logs)
+    
+    def compare_logs(self, clp_logs: List[str], segment_logs: List[str]):
+        self.assertEqual(len(clp_logs), len(segment_logs))
+        for clp_log, segment_log in zip(clp_logs, segment_logs):
+            self.assertEqual(clp_log, segment_log)
+            
+    def setup_logging(self) -> None:
+        self.clp_handler: CLPStreamHandler = CLPFileHandler(
+            self.clp_log_path, enable_compression=self.enable_compression
+        )
+        self.logger: logging.Logger = logging.getLogger(self.id())
+        self.logger.setLevel(logging.DEBUG)
+        self.clp_handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+        self.logger.addHandler(self.clp_handler)
+
+    def test_log(self) -> None:
+        for i in range(100):
+            self.logger.info(f"Log message #{i}")
+            # Static log
+            self.logger.info("static text log one")
+            self.logger.info("static text log two")
+            # Int
+            self.logger.info("int 3190")
+            self.logger.info("-int -3190")
+            # Float
+            self.logger.info("float 31.90")
+            self.logger.info("-float -31.90")
+            # Dict
+            self.logger.info("textint test1234")
+            self.logger.info("texteq=var")
+            self.logger.info(f">32bit int: {2**32}")
+            # Combo
+            self.logger.info("zxcvbn 1234 asdfgh 12.34 qwerty")
+            self.logger.info("zxcvbn -1234 asdfgh -12.34 qwerty")
+            self.logger.info("zxcvbn foo=bar asdfgh foobar=var321 qwerty")
+            # Level
+            self.logger.debug("zxcvbn 1234 asdfgh 12.34 qwerty")
+            self.logger.debug("zxcvbn -1234 asdfgh -12.34 qwerty")
+            self.logger.debug("zxcvbn foo=bar asdfgh foobar=var321 qwerty")
+        self.compare_all_logs()
+
+class TestCLPSegmentStreaming_ZSTD(TestCLPSegmentStreamingBase):
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = True
+        self.segment_size = 4096
+        super().setUp()
+        self.setup_logging()
+        
+class TestCLPSegmentStreaming_RAW(TestCLPSegmentStreamingBase):
+    # override
+    def setUp(self) -> None:
+        self.enable_compression = False
+        self.segment_size = 4096
+        super().setUp()
+        self.setup_logging()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# References
There is a typo found in the "CLPSegmentStreaming" section from README.md. Also, there were mypy errors left from the previous PR.

# Description
Fix the typo in README.md, and rephrase the description in the "CLPSegmentStreaming" section.
Fix mypy errors in both src/clp_logging/reader.py and tests/test_handlers.py.

# Validation performed
Pass mypy check.
Pass all the existing unittests.

