### PR TITLE
Update project settings and relax unit test timestamp delta.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
     "python-dateutil >= 2.7.0",
+    "smart_open >= 6.3.0",
     "typing-extensions >= 4.1.1",
     "zstandard >= 0.18.0",
 ]
@@ -39,7 +40,7 @@ wrap-summaries = 80
 wrap-descriptions = 80
 
 [tool.black]
-line-length = 99
+line-length = 100
 target-version = ["py311"]
 color = true
 preview = true

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -259,9 +259,7 @@ class CLPLogLevelTimeout:
         if new_hard_timeout_ts < self.next_hard_timeout_ts:
             if self.hard_timeout_thread:
                 self.hard_timeout_thread.cancel()
-            self.hard_timeout_thread = Timer(
-                new_hard_timeout_ts / 1000 - time.time(), self.timeout
-            )
+            self.hard_timeout_thread = Timer(new_hard_timeout_ts / 1000 - time.time(), self.timeout)
             self.hard_timeout_thread.setDaemon(True)
             self.hard_timeout_thread.start()
             self.next_hard_timeout_ts = new_hard_timeout_ts

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -299,9 +299,7 @@ class CLPBaseReader(metaclass=ABCMeta):
                 elif token_type == -1:
                     break
                 elif token_type < -1:
-                    raise RuntimeError(
-                        f"Error decoding token: 0x{token.hex()}, type: {token_type}"
-                    )
+                    raise RuntimeError(f"Error decoding token: 0x{token.hex()}, type: {token_type}")
                 offset += pos
 
                 if log:
@@ -347,9 +345,7 @@ class CLPBaseReader(metaclass=ABCMeta):
                 t = RE_DELIM_VAR_UNESCAPE.sub(RE_SUB_DELIM_VAR_UNESCAPE, t)
             log.encoded_variables.append(t)
         elif token_id == ID_LOGTYPE:
-            log.encoded_logtype = RE_DELIM_VAR_UNESCAPE.sub(
-                RE_SUB_DELIM_VAR_UNESCAPE, bytes(token)
-            )
+            log.encoded_logtype = RE_DELIM_VAR_UNESCAPE.sub(RE_SUB_DELIM_VAR_UNESCAPE, bytes(token))
         elif token_id == ID_TIMESTAMP:
             delta_ms: int = int.from_bytes(token, BYTE_ORDER, signed=True)
             log.timestamp_ms = self.last_timestamp_ms + delta_ms
@@ -618,9 +614,7 @@ class _CLPSegmentStreamingReader:
                 elif token_type == -1:
                     break  # Populate the buffer and decode again
                 elif token_type < -1:
-                    raise RuntimeError(
-                        f"Error decoding token: 0x{token.hex()}, type: {token_type}"
-                    )
+                    raise RuntimeError(f"Error decoding token: 0x{token.hex()}, type: {token_type}")
 
                 log_buf += self.view[offset : offset + pos]
                 offset += pos

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -49,6 +49,7 @@ def _zstd_comppressions_handler(
 register_compressor(".zst", _zstd_comppressions_handler)
 
 LOG_DIR: Path = Path("unittest-logs")
+TIMESTAMP_DELTA_MS: int = 64
 
 
 # TODO: revisit type ignore if minimum python version increased
@@ -169,7 +170,7 @@ class TestCLPBase(unittest.TestCase):
                 clp_timestamp: datetime = dateutil.parser.isoparse(clp_time_str)
                 raw_timestamp: datetime = dateutil.parser.isoparse(raw_time_str)
                 self.assertAlmostEqual(
-                    clp_timestamp, raw_timestamp, delta=timedelta(milliseconds=32)
+                    clp_timestamp, raw_timestamp, delta=timedelta(milliseconds=TIMESTAMP_DELTA_MS)
                 )
 
             clp_msg: str = " ".join(clp_log_split[2:])
@@ -361,7 +362,7 @@ class TestCLPLogLevelTimeoutBase(TestCLPBase):
             self.assertAlmostEqual(
                 datetime.fromtimestamp(timeout_ts[i]),  # type: ignore
                 datetime.fromtimestamp(start_ts + expected_timeout_deltas[i]),
-                delta=timedelta(milliseconds=64),
+                delta=timedelta(milliseconds=TIMESTAMP_DELTA_MS),
             )
 
     def test_pushback_soft_timeout(self) -> None:


### PR DESCRIPTION
# Description
The new coding policy updates the line-length from 99 characters to 100 characters.
In addition, the timestamp delta in the unit test for "almostequal" comparison was too strict. Sometimes the unit tests fail without having real issues. This PR replaces the old delta with a global constant which relaxes the constraints.

# Validation performed
All unit tests passed.

