### PR TITLE
Downgrade required version of typing-extensions to improve compatibility with other dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.6"
 dependencies = [
     "python-dateutil >= 2.7.0",
     "smart_open >= 6.3.0",
-    "typing-extensions >= 4.1.1",
+    "typing-extensions >= 3.7.4",
     "zstandard >= 0.18.0",
 ]
 classifiers = [


### PR DESCRIPTION
# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

`clp_logging` currently depends on `typing-extensions >= 4.4.0`. Some users have reported compatibility issues with other packages when the other package has a lower required version of `typing-extensions`. Thus, this PR lowers the required version of typing-extensions to improve compatibility.

Note that although `clp_logging` doesn't need `typing-extensions` v4.4.0, our tooling (`mypy`, `black`, etc.) does, so that's why we use `>=`.

# Validation performed
<!-- What tests and validation you performed on the change -->
* Ran a clean build and verified unit tests pass
* Created a project that depends on both `clp_logging` and a package with a lower required version of `typing-extensions`; ensured there was no incompatibility.
