### PR TITLE
Update clp-ffi-py and development tools dependencies

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - run: black --diff --check src/ tests/
 
-      - run: ruff check --format=github src/ tests/
+      - run: ruff check --output-format=github src/ tests/
 
       - run: mypy src/ tests/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Logging/encoding/decoding using CLP's IR stream format"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "clp-ffi-py >= 0.0.7",
+    "clp-ffi-py >= 0.0.8",
     "python-dateutil >= 2.7.0",
     "typing-extensions >= 3.7.4",
     "zstandard >= 0.18.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Logging/encoding/decoding using CLP's IR stream format"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "clp-ffi-py == 0.0.9b0",
+    "clp-ffi-py >= 0.0.9",
     "python-dateutil >= 2.7.0",
     "typing-extensions >= 3.7.4",
     "zstandard >= 0.18.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Logging/encoding/decoding using CLP's IR stream format"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "clp-ffi-py >= 0.0.9b0",
+    "clp-ffi-py == 0.0.9b0",
     "python-dateutil >= 2.7.0",
     "typing-extensions >= 3.7.4",
     "zstandard >= 0.18.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Logging/encoding/decoding using CLP's IR stream format"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "clp-ffi-py >= 0.0.8",
+    "clp-ffi-py >= 0.0.9b0",
     "python-dateutil >= 2.7.0",
     "typing-extensions >= 3.7.4",
     "zstandard >= 0.18.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
     "build >= 0.8.0",
     "docformatter >= 1.5.1",
     "mypy >= 0.982",
-    "ruff >= 0.0.275",
+    "ruff >= 0.1.5",
     "types-python-dateutil >= 2.8.19.2",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Logging/encoding/decoding using CLP's IR stream format"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "clp-ffi-py >= 0.0.1",
+    "clp-ffi-py >= 0.0.7",
     "python-dateutil >= 2.7.0",
     "typing-extensions >= 3.7.4",
     "zstandard >= 0.18.0",
@@ -24,7 +24,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "black >= 22.10.0",
+    "black >= 23.11.0",
     "build >= 0.8.0",
     "docformatter >= 1.5.1",
     "mypy >= 0.982",

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -237,25 +237,25 @@ class TestCLPHandlerBase(TestCLPBase):
         self.clp_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
         self.raw_handler.setFormatter(logging.Formatter(" [%(levelname)s] %(message)s"))
         self.logger.info("format starts with %(asctime)s")
-        self.assert_clp_logs(
-            [f"{WARN_PREFIX.lstrip()} replacing '%(asctime)s' with clp_logging timestamp format"]
-        )
+        self.assert_clp_logs([
+            f"{WARN_PREFIX.lstrip()} replacing '%(asctime)s' with clp_logging timestamp format"
+        ])
 
     def test_time_format_in_middle(self) -> None:
         fmt: str = "[%(levelname)s] %(asctime)s %(message)s"
         self.clp_handler.setFormatter(logging.Formatter(fmt))
         self.logger.info("format has %(asctime)s in the middle")
-        self.assert_clp_logs(
-            [f"{WARN_PREFIX.lstrip()} replacing '{fmt}' with '{DEFAULT_LOG_FORMAT}'"]
-        )
+        self.assert_clp_logs([
+            f"{WARN_PREFIX.lstrip()} replacing '{fmt}' with '{DEFAULT_LOG_FORMAT}'"
+        ])
 
     def test_time_format_missing(self) -> None:
         self.clp_handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
         self.raw_handler.setFormatter(logging.Formatter(" [%(levelname)s] %(message)s"))
         self.logger.info("no asctime in format")
-        self.assert_clp_logs(
-            [f"{WARN_PREFIX.lstrip()} prepending clp_logging timestamp to formatter"]
-        )
+        self.assert_clp_logs([
+            f"{WARN_PREFIX.lstrip()} prepending clp_logging timestamp to formatter"
+        ])
 
     def test_static(self) -> None:
         self.logger.info("static text log one")
@@ -322,18 +322,16 @@ class TestCLPLogLevelTimeoutBase(TestCLPBase):
         self._setup_handler()
 
         self.logger.debug("debug log0")
-        self.assert_clp_logs(
-            [
-                (
-                    f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
-                    " self.hard_timeout_deltas; defaulting to _HARD_TIMEOUT_DELTAS[logging.INFO]."
-                ),
-                (
-                    f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
-                    " self.soft_timeout_deltas; defaulting to _SOFT_TIMEOUT_DELTAS[logging.INFO]."
-                ),
-            ]
-        )
+        self.assert_clp_logs([
+            (
+                f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
+                " self.hard_timeout_deltas; defaulting to _HARD_TIMEOUT_DELTAS[logging.INFO]."
+            ),
+            (
+                f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
+                " self.soft_timeout_deltas; defaulting to _SOFT_TIMEOUT_DELTAS[logging.INFO]."
+            ),
+        ])
 
     def _test_timeout(
         self,


### PR DESCRIPTION
# Description
1. Update `clp-ffi-py` to the latest release version to fix the encoding problem: https://github.com/y-scope/clp/pull/171
2. Update `black` to ensure that the github workflow can pass
3. Update `ruff` and its github workflow instructions to the latest release version

