### PR TITLE
Update linter and test dependencies to fix the failed workflow.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "black >= 23.11.0",
+    "black >= 24.4.0",
     "build >= 0.8.0",
-    "docformatter >= 1.5.1",
-    "mypy >= 0.982",
-    "ruff >= 0.1.5",
+    "docformatter >= 1.7.5",
+    "mypy >= 1.9.0",
+    "ruff >= 0.3.7",
     "types-python-dateutil >= 2.8.19.2",
 ]
 test = [
@@ -58,10 +58,10 @@ pretty = true
 
 [tool.ruff]
 line-length = 100
-select = ["E", "I", "F"]
 src = ["src"]
 
-[tool.ruff.isort]
-order-by-type = false
+[tool.ruff.lint]
+isort.order-by-type = false
+select = ["E", "I", "F"]
 
 [tool.setuptools_scm]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,1 @@
-smart_open>=6.3.0
+smart_open==6.4.0

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -237,25 +237,25 @@ class TestCLPHandlerBase(TestCLPBase):
         self.clp_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
         self.raw_handler.setFormatter(logging.Formatter(" [%(levelname)s] %(message)s"))
         self.logger.info("format starts with %(asctime)s")
-        self.assert_clp_logs([
-            f"{WARN_PREFIX.lstrip()} replacing '%(asctime)s' with clp_logging timestamp format"
-        ])
+        self.assert_clp_logs(
+            [f"{WARN_PREFIX.lstrip()} replacing '%(asctime)s' with clp_logging timestamp format"]
+        )
 
     def test_time_format_in_middle(self) -> None:
         fmt: str = "[%(levelname)s] %(asctime)s %(message)s"
         self.clp_handler.setFormatter(logging.Formatter(fmt))
         self.logger.info("format has %(asctime)s in the middle")
-        self.assert_clp_logs([
-            f"{WARN_PREFIX.lstrip()} replacing '{fmt}' with '{DEFAULT_LOG_FORMAT}'"
-        ])
+        self.assert_clp_logs(
+            [f"{WARN_PREFIX.lstrip()} replacing '{fmt}' with '{DEFAULT_LOG_FORMAT}'"]
+        )
 
     def test_time_format_missing(self) -> None:
         self.clp_handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
         self.raw_handler.setFormatter(logging.Formatter(" [%(levelname)s] %(message)s"))
         self.logger.info("no asctime in format")
-        self.assert_clp_logs([
-            f"{WARN_PREFIX.lstrip()} prepending clp_logging timestamp to formatter"
-        ])
+        self.assert_clp_logs(
+            [f"{WARN_PREFIX.lstrip()} prepending clp_logging timestamp to formatter"]
+        )
 
     def test_static(self) -> None:
         self.logger.info("static text log one")
@@ -322,16 +322,18 @@ class TestCLPLogLevelTimeoutBase(TestCLPBase):
         self._setup_handler()
 
         self.logger.debug("debug log0")
-        self.assert_clp_logs([
-            (
-                f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
-                " self.hard_timeout_deltas; defaulting to _HARD_TIMEOUT_DELTAS[logging.INFO]."
-            ),
-            (
-                f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
-                " self.soft_timeout_deltas; defaulting to _SOFT_TIMEOUT_DELTAS[logging.INFO]."
-            ),
-        ])
+        self.assert_clp_logs(
+            [
+                (
+                    f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
+                    " self.hard_timeout_deltas; defaulting to _HARD_TIMEOUT_DELTAS[logging.INFO]."
+                ),
+                (
+                    f"{WARN_PREFIX.lstrip()} log level {logging.DEBUG} not in"
+                    " self.soft_timeout_deltas; defaulting to _SOFT_TIMEOUT_DELTAS[logging.INFO]."
+                ),
+            ]
+        )
 
     def _test_timeout(
         self,


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The current linter workflow failed because linter dependencies were outdated. One source file needs to be refactored after updating the linter versions. This PR also updates the test dependencies to lock `smart_open` version to 6.4.0 to make it compatible with Python3.6 and Python zstandard.

# Validation performed
<!-- What tests and validation you performed on the change -->
Ensured GH workflow passed.

