### PR TITLE
Replace dateutil.tz with ZoneInfo and tzlocal for better cross-platform compatibility.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "backports.zoneinfo >= 0.2.1; python_version<'3.9'",
     "clp-ffi-py >= 0.0.9",
     "typing-extensions >= 3.7.4",
-	"tzlocal >= 5.2",
+    "tzlocal >= 5.2",
     "zstandard >= 0.18.0",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ description = "Logging/encoding/decoding using CLP's IR stream format"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
+    "backports.zoneinfo >= 0.2.1; python_version<'3.9'",
     "clp-ffi-py >= 0.0.9",
     "typing-extensions >= 3.7.4",
 	"tzlocal >= 5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "backports.zoneinfo >= 0.2.1; python_version < '3.9'",
     "clp-ffi-py >= 0.0.9",
     "typing-extensions >= 3.7.4",
-    "tzlocal >= 5.2",
+    "tzlocal == 5.1; python_version < '3.8'",
+    "tzlocal >= 5.2; python_version >= '3.8'",
     "zstandard >= 0.18.0",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ description = "Logging/encoding/decoding using CLP's IR stream format"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
-    "backports.zoneinfo >= 0.2.1; python_version<'3.9'",
+    "backports.zoneinfo >= 0.2.1; python_version < '3.9'",
     "clp-ffi-py >= 0.0.9",
     "typing-extensions >= 3.7.4",
     "tzlocal >= 5.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
     "clp-ffi-py >= 0.0.9",
-    "python-dateutil >= 2.7.0",
     "typing-extensions >= 3.7.4",
+	"tzlocal >= 5.2",
     "zstandard >= 0.18.0",
 ]
 classifiers = [

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -58,7 +58,10 @@ def _init_timeinfo(fmt: Optional[str], tz: Optional[str]) -> Tuple[str, str]:
     if not fmt:
         fmt = "yyyy-MM-d H:m:s.A"
     if not tz:
-        tz = tzlocal.get_localzone_name()
+        try:
+            tz = tzlocal.get_localzone_name()
+        except Exception:
+            tz = "UTC"
 
     return fmt, tz
 

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -4,7 +4,6 @@ import socket
 import sys
 import time
 from abc import ABCMeta, abstractmethod
-from datetime import tzinfo
 from math import floor
 from pathlib import Path
 from queue import Empty, Queue

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -13,7 +13,7 @@ from threading import Thread, Timer
 from types import FrameType
 from typing import Callable, ClassVar, Dict, IO, Optional, Tuple, Union
 
-import dateutil.tz
+import tzlocal
 from clp_ffi_py.ir import FourByteEncoder
 from zstandard import FLUSH_FRAME, ZstdCompressionWriter, ZstdCompressor
 
@@ -59,12 +59,8 @@ def _init_timeinfo(fmt: Optional[str], tz: Optional[str]) -> Tuple[str, str]:
     if not fmt:
         fmt = "yyyy-MM-d H:m:s.A"
     if not tz:
-        tzf: Optional[tzinfo] = dateutil.tz.gettz()
-        if tzf:
-            tzp: Path = Path.resolve(Path(tzf._filename))  # type: ignore
-            tz = "/".join([tzp.parent.name, tzp.name])
-        else:
-            tz = "UTC"
+        tz = tzlocal.get_localzone_name()
+
     return fmt, tz
 
 

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -31,9 +31,11 @@ from clp_logging.protocol import (
 )
 
 try:
-    from zoneinfo import ZoneInfo
+    from zoneinfo import ZoneInfo  # type: ignore[import-not-found, unused-ignore]
 except ImportError:
-    from backports.zoneinfo import ZoneInfo
+    from backports.zoneinfo import (  # type: ignore[import-not-found, no-redef, unused-ignore]
+        ZoneInfo,
+    )
 
 
 class Log:

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from sys import stderr
 from types import TracebackType
 from typing import IO, Iterator, List, Match, Optional, Tuple, Type, Union
+from zoneinfo import ZoneInfo
 
-import dateutil.tz
 from clp_ffi_py.ir import FourByteEncoder
 from zstandard import ZstdDecompressionReader, ZstdDecompressor
 
@@ -186,7 +186,7 @@ class CLPBaseReader(metaclass=ABCMeta):
             # We do not use the timestamp pattern from the preamble as it may
             # be from other languages and therefore incompatible.
             # self.timestamp_format = self.metadata[METADATA_TIMESTAMP_PATTERN_KEY]
-            self.timezone = dateutil.tz.gettz(self.metadata[METADATA_TZ_ID_KEY])
+            self.timezone = ZoneInfo(self.metadata[METADATA_TZ_ID_KEY])
         return self.pos
 
     @abstractmethod

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -35,6 +35,7 @@ try:
 except ImportError:
     from backports.zoneinfo import ZoneInfo
 
+
 class Log:
     """
     An object representing a `logging` record. It is created and returned by

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from datetime import datetime, tzinfo
+from datetime import datetime
 from pathlib import Path
 from sys import stderr
 from types import TracebackType
@@ -67,7 +67,7 @@ class Log:
     def __str__(self) -> str:
         return self.formatted_msg
 
-    def _decode(self, timestamp_format: Optional[str], timezone: Optional[tzinfo]) -> int:
+    def _decode(self, timestamp_format: Optional[str], timezone: Optional[ZoneInfo]) -> int:
         """
         Populate the `variables`, `msg`, and `formatted_msg` fields by decoding
         the encoded `encoded_logtype and `encoded_variables`.
@@ -154,7 +154,7 @@ class CLPBaseReader(metaclass=ABCMeta):
         self.metadata: Optional[Metadata] = None
         self.last_timestamp_ms: int
         self.timestamp_format: Optional[str] = timestamp_format
-        self.timezone: Optional[tzinfo]
+        self.timezone: Optional[ZoneInfo]
         self.pos: int
 
     def read_preamble(self) -> int:

--- a/src/clp_logging/readers.py
+++ b/src/clp_logging/readers.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from sys import stderr
 from types import TracebackType
 from typing import IO, Iterator, List, Match, Optional, Tuple, Type, Union
-from zoneinfo import ZoneInfo
 
 from clp_ffi_py.ir import FourByteEncoder
 from zstandard import ZstdDecompressionReader, ZstdDecompressor
@@ -31,6 +30,10 @@ from clp_logging.protocol import (
     VAR_COMPACT_ENCODING,
 )
 
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
 
 class Log:
     """


### PR DESCRIPTION
# References
It was found on Windows that running below snippet would raise an exception of `AttributeError`.
### Example code:
```python3
import logging
from pathlib import Path
from clp_logging.handlers import CLPFileHandler

clp_handler = CLPFileHandler(Path("example.clp.zst"))
logger = logging.getLogger(__name__)
logger.addHandler(clp_handler)
logger.warn("example warning")
```

### Exception:
```bash
Traceback (most recent call last):
  File "R:\test-loglib\pythonProject\main.py", line 6, in <module>
    clp_handler = CLPFileHandler(Path("example.clp.zst"))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Junhao\AppData\Roaming\Python\Python311\site-packages\clp_logging\handlers.py", line 794, in __init__
    super().__init__(
  File "C:\Users\Junhao\AppData\Roaming\Python\Python311\site-packages\clp_logging\handlers.py", line 726, in __init__
    self.timestamp_format, self.timezone = _init_timeinfo(timestamp_format, timezone)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Junhao\AppData\Roaming\Python\Python311\site-packages\clp_logging\handlers.py", line 64, in _init_timeinfo
    tzp: Path = Path.resolve(Path(tzf._filename))  # type: ignore
                                  ^^^^^^^^^^^^^
AttributeError: 'tzlocal' object has no attribute '_filename'

```
Further analysis found attribute `_filename` does not exist on the object returned by `dateutil.tz.gettz()` because the Windows implementation is different than the Linux one, where the `_filename` attribute does exist.

# Description
1. Replaced usage of dateutil.tz.gettz in `clp_logging/readers.py` to get time zone information with Python's built-in zoneinfo.ZoneInfo (with a fallback to `backports.zoneinfo.ZoneInfo` when the Python version is below 3.9).
2. Replaced usage of dateutil.tz.gettz in `clp_logging/handlers.py` to get IANA current time zone name with third-party tzlocal library.
3. Added `backports.zoneinfo` to project requirements in `pyproject.toml` for getting local time zone from IANA names.
4. Added `tzlocal` to project requirements in `pyproject.toml` for getting local time zone name.

# Validation performed
Run this snippet on Windows without observing any errors:
```python3
import logging
from pathlib import Path
from typing import List

from clp_logging.handlers import CLPFileHandler
from clp_logging.readers import CLPFileReader, Log

clp_handler = CLPFileHandler(Path("example.clp.zst"))
logger = logging.getLogger(__name__)
logger.addHandler(clp_handler)
logger.warning("example warning")

# create a list of all Log objects
log_objects: List[Log] = []
with CLPFileReader(Path("example.clp.zst")) as clp_reader:
    for log in clp_reader:
        log_objects.append(log)
    print(log)

```
### Output:
```bash
2024-04-20 00:40:30.899-04:00 WARNING __main__ example warning

```