### PR TITLE
ci: Fix workflow failure caused by missing Python 3.7 in the latest macOS runner.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.11"]
+        python-version: ["3.7.17", "3.8", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,12 +38,12 @@ jobs:
           path: dist/*
           retention-days: 1
 
-  test-python3.7:
+  test-python37:
     needs: [build]
     strategy:
       matrix:
         os: [macos-13, ubuntu-latest]
-        python-version: "3.7"
+        python-version: ["3.7"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,12 +38,12 @@ jobs:
           path: dist/*
           retention-days: 1
 
-  test:
+  test-python3.7:
     needs: [build]
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
-        python-version: ["3.7.17", "3.8", "3.11"]
+        os: [macos-13, ubuntu-latest]
+        python-version: "3.7"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -53,18 +53,37 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels for Python3.7
-        if: ${{ '3.7' == matrix.python-version }}
         uses: actions/download-artifact@v3
         with:
           name: wheel-3.8
           path: dist/
 
       - name: Download wheels for Built Python Versions
-        if: ${{ '3.7' != matrix.python-version }}
         uses: actions/download-artifact@v3
         with:
           name: wheel-${{ matrix.python-version }}
           path: dist/
+
+      - run: pip install --upgrade
+          pip
+          dist/clp_logging-*.whl
+          -r requirements-test.txt
+
+      - run: python -m unittest -fv
+
+  test:
+    needs: [build]
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        python-version: ["3.8", "3.11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - run: pip install --upgrade
           pip

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Download wheels for Python3.7
         uses: actions/download-artifact@v3
         with:
+          # Since we don't build for Python 3.7, we download the Python 3.8 wheel instead
           name: wheel-3.8
           path: dist/
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Download wheels for Python3.7
         uses: actions/download-artifact@v3
         with:
-          # Since we don't build for Python 3.7, we download the Python 3.8 wheel instead
+          # Since we don't build for Python 3.7, we download the Python 3.8 wheel instead.
           name: wheel-3.8
           path: dist/
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -58,12 +58,6 @@ jobs:
           name: wheel-3.8
           path: dist/
 
-      - name: Download wheels for Built Python Versions
-        uses: actions/download-artifact@v3
-        with:
-          name: wheel-3.8
-          path: dist/
-
       - run: pip install --upgrade
           pip
           dist/clp_logging-*.whl

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Download wheels for Built Python Versions
         uses: actions/download-artifact@v3
         with:
-          name: wheel-${{ matrix.python-version }}
+          name: wheel-3.8
           path: dist/
 
       - run: pip install --upgrade
@@ -84,6 +84,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Download wheels for Built Python Versions
+        uses: actions/download-artifact@v3
+        with:
+          name: wheel-${{ matrix.python-version }}
+          path: dist/
 
       - run: pip install --upgrade
           pip


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
The package workflow failed in the current repo: https://github.com/LinZhihao-723/clp-loglib-py/actions/runs/12060286918, which is because Python3.7 is no longer valid in the latest macos runner (macos14) for arm64.
This PR fixes the issue by testing Python3.7 in macos13. It redoes part of the changes in #41 to create a stand-alone test section for Python 3.7 to facilitate the management of our workflow config. It also makes it easier to fully remove Python 3.7 testing if we drop support for Python 3.7 (which may be soon 'cuz Python 3.7 has been reached EOL for longer than a year). For Python versions higher than 3.7, we stick to the latest macos runner to ensure the Apple silicon is tested.


# Validation performed
<!-- What tests and validation you performed on the change -->
Ensure workflows all passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new testing job for Python versions 3.8 and 3.11.

- **Changes**
	- Renamed the existing test job to focus solely on Python 3.7.
	- Simplified testing configurations for better clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->