### PR TITLE
ci: Add GH workflow to validate PR titles follow Conventional Commits (fixes #43).

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 Set the PR title to a meaningful commit message that:
 - follows the Conventional Commits specification (https://www.conventionalcommits.org).
 - is in imperative form.
+
 Example:
 fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,10 @@
-# References
-<!-- Any issues or pull requests relevant to this pull request -->
+<!--
+Set the PR title to a meaningful commit message that:
+- follows the Conventional Commits specification (https://www.conventionalcommits.org).
+- is in imperative form.
+Example:
+fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
+-->
 
 # Description
 <!-- Describe what this request will change/fix and provide any details necessary for reviewers -->

--- a/.github/workflows/pr-title-checks.yaml
+++ b/.github/workflows/pr-title-checks.yaml
@@ -2,6 +2,11 @@ name: "pr-title-checks"
 
 on:
   pull_request_target:
+    # NOTE: The `pull_request_target` event means GITHUB_TOKEN can access secrets and is granted
+    # read/write repository access by default. So we need to ensure:
+    # - This workflow doesn't inadvertently check out, build, or execute untrusted code from the
+    #   pull request triggered by this event.
+    # - Each job has `permissions` set to only those necessary.
     types: ["edited", "opened", "reopened"]
     branches: ["main"]
 

--- a/.github/workflows/pr-title-checks.yaml
+++ b/.github/workflows/pr-title-checks.yaml
@@ -9,6 +9,7 @@ on:
     # - Each job has `permissions` set to only those necessary.
     types: ["edited", "opened", "reopened"]
     branches: ["main"]
+
 permissions: {}
 
 concurrency:

--- a/.github/workflows/pr-title-checks.yaml
+++ b/.github/workflows/pr-title-checks.yaml
@@ -1,0 +1,23 @@
+name: "pr-title-checks"
+
+on:
+  pull_request_target:
+    types: ["edited", "opened", "reopened"]
+    branches: ["main"]
+
+concurrency:
+  group: "${{github.workflow}}-${{github.ref}}"
+
+  # Cancel in-progress jobs for efficiency
+  cancel-in-progress: true
+
+jobs:
+  conventional-commits:
+    permissions:
+      # For amannn/action-semantic-pull-request
+      pull-requests: "read"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "amannn/action-semantic-pull-request@v5"
+        env:
+          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"

--- a/.github/workflows/pr-title-checks.yaml
+++ b/.github/workflows/pr-title-checks.yaml
@@ -2,13 +2,14 @@ name: "pr-title-checks"
 
 on:
   pull_request_target:
-    # NOTE: The `pull_request_target` event means GITHUB_TOKEN can access secrets and is granted
-    # read/write repository access by default. So we need to ensure:
+    # NOTE: Workflows triggered by this event give the workflow access to secrets and grant the
+    # `GITHUB_TOKEN` read/write repository access by default. So we need to ensure:
     # - This workflow doesn't inadvertently check out, build, or execute untrusted code from the
     #   pull request triggered by this event.
     # - Each job has `permissions` set to only those necessary.
     types: ["edited", "opened", "reopened"]
     branches: ["main"]
+permissions: {}
 
 concurrency:
   group: "${{github.workflow}}-${{github.ref}}"


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
This PR implements #43 

[Convention Commits](https://www.conventionalcommits.org) is a specification for writing commit messages (or in our case, PR titles) that makes it easy to see at a glance what change the commit makes which in turn makes it easier to generate release notes.

This PR adds a workflow to check PR titles match the spec.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Already validated this workflow in other repos, including CLP core, log surgeon, and clp-ffi-py.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow to validate pull request titles based on the Conventional Commits specification.
	- Updated the pull request template to provide guidance on writing effective titles.

- **Documentation**
	- Removed the "References" section from the pull request template and added comments to improve clarity on title formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->