### PR TITLE
ci: Update to latest versions of all GH actions.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -32,7 +32,7 @@ jobs:
 
       - run: python -m build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.python-version }}
           path: dist/*
@@ -46,14 +46,14 @@ jobs:
         python-version: ["3.7"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels for Python3.7
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           # Since we don't build for Python 3.7, we download the Python 3.8 wheel instead.
           name: wheel-3.8
@@ -74,14 +74,14 @@ jobs:
         python-version: ["3.8", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download wheels for Built Python Versions
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheel-${{ matrix.python-version }}
           path: dist/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,13 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheel-3.8
           path: dist/


### PR DESCRIPTION
# References
<!-- Any issues or pull requests relevant to this pull request -->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
As indicated in the recent workflows, artifact action v3 has been deprecated: https://github.com/y-scope/clp-loglib-py/actions/runs/12093018591
This PR updates all GH action dependencies to the latest release:
- actions/checkout: v3 -> v4
- actions/download-artifact: v3 -> v4
- actions/upload-artifact: v3 -> v4
- actions/setup-python: v4 -> v5

# Validation performed
<!-- What tests and validation you performed on the change -->
Ensure the updated workflows passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations for linting, building, and testing the Python package to utilize the latest action versions.
	- Enhanced the workflow for uploading packages to PyPI with updated action versions for improved performance and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->