### PR TITLE
ci: Explicitly use ubunutu-22.04 to test wheels for Python3.7. 

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -42,7 +42,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        os: [macos-13, ubuntu-latest]
+        os: [macos-13, ubuntu-22.04]
         python-version: ["3.7"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message that:
- follows the Conventional Commits specification (https://www.conventionalcommits.org).
- is in imperative form.

Example:
fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers -->
Reference: https://github.com/y-scope/clp-loglib-py/actions/runs/12837435781/job/35801116566?pr=51
ubuntu-latest has been upgraded to Ubuntu 24.04 which doesn't support Python 3.7. This PR changes Python 3.7's testing env from `ubuntu-latest` to `ubuntu-22.04` explicitly to ensure the workflow can be successfully launched.

# Validation performed
<!-- What tests and validation you performed on the change -->
- Ensure all workflows passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to use Ubuntu 22.04 for Python 3.7 testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->