### PR TITLE
docs: Clarify description of the UTC offset in `ClpKeyValuePairStreamHandler`'s auto-generated timestamp kv-pair.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The handler adds the following auto-generated kv-pairs to each log event:
 |---------------------|------------|----------------------------------------------------|
 | `timestamp`         | `dict`     | The log event's timestamp                          |
 | - `unix_millisecs`  | `int`      | The timestamp in milliseconds since the Unix epoch |
-| - `utc_offset_secs` | `int`      | The timestamp's UTC offset in seconds              |
+| - `utc_offset_secs` | `int`      | The timestamp's offset fom UTC, in seconds         |
 | `level`             | `dict`     | The log event's level                              |
 | - `name`            | `str`      | The level's name                                   |
 | - `num`             | `int`      | The level's numeric value                          |


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR is to fix the comment missed in #56: https://github.com/y-scope/clp-loglib-py/pull/56#discussion_r1961366918

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Ensure the doc can be successfully rendered.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity on the description of the UTC offset key.
  - Added a note indicating the limitation on applying formatting to structured log events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->