### PR TITLE
feat: Add mutual exclusion for synchronized stream access in logging handlers and `CLPLoglevelTimeout` (fixes #55).

### DIFF
--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -315,6 +315,14 @@ class CLPLogLevelTimeout:
 def _get_mutex_context_from_loglevel_timeout(
     loglevel_timeout: Optional[CLPLogLevelTimeout],
 ) -> AbstractContextManager[bool | None]:
+    """
+    Returns a context manager from the lock given by `loglevel_timeout`. If
+    `loglevel_timeout` is `None`, it returns a `nullcontext()` instead.
+
+    :param loglevel_timeout: An optional `CLPLogLevelTimeout` object.
+    :return: The lock from `loglevel_timeout` if it is not `None`,
+        or a `nullcontext()` if it is `None`.
+    """
     return loglevel_timeout.get_lock() if loglevel_timeout else nullcontext()
 
 

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -312,11 +312,13 @@ class CLPLogLevelTimeout:
         self.soft_timeout_thread.start()
 
 
-def _get_mutex_context_from_loglevel_timeout(
-    loglevel_timeout: Optional[CLPLogLevelTimeout],
-) -> AbstractContextManager[Optional[bool]]:
+def _get_mutex_context_from_loglevel_timeout(loglevel_timeout: Optional[CLPLogLevelTimeout]) -> Any:
     """
     Gets a mutual exclusive context manager for IR stream access.
+
+    The return type should be `AbstractContextManager[Optional[bool]]`, but it
+    is annotated as `Any` for backward compatibility, since the generic
+    `AbstractContextManager` is not available before Python 3.9 (#18239).
 
     :param loglevel_timeout: An optional `CLPLogLevelTimeout` object.
     :return: A context manager that either provides the lock from

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -240,21 +240,20 @@ class CLPLogLevelTimeout:
         existing timeout threads are cancelled, `next_hard_timeout_ts` and
         `min_soft_timeout_delta` are reset, and the zstandard frame is flushed.
         """
-        self.get_lock().acquire()
-        if self.hard_timeout_thread:
-            self.hard_timeout_thread.cancel()
-        if self.soft_timeout_thread:
-            self.soft_timeout_thread.cancel()
-        self.next_hard_timeout_ts = ULONG_MAX
-        self.min_soft_timeout_delta = ULONG_MAX
+        with self.get_lock():
+            if self.hard_timeout_thread:
+                self.hard_timeout_thread.cancel()
+            if self.soft_timeout_thread:
+                self.soft_timeout_thread.cancel()
+            self.next_hard_timeout_ts = ULONG_MAX
+            self.min_soft_timeout_delta = ULONG_MAX
 
-        if self.ostream:
-            if isinstance(self.ostream, ZstdCompressionWriter):
-                self.ostream.flush(FLUSH_FRAME)
-            else:
-                self.ostream.flush()
-        self.timeout_fn()
-        self.get_lock().release()
+            if self.ostream:
+                if isinstance(self.ostream, ZstdCompressionWriter):
+                    self.ostream.flush(FLUSH_FRAME)
+                else:
+                    self.ostream.flush()
+            self.timeout_fn()
 
     def update(self, loglevel: int, log_timestamp_ms: int, log_fn: Callable[[str], None]) -> None:
         """
@@ -268,46 +267,47 @@ class CLPLogLevelTimeout:
             allows us to correctly log through the handler itself rather than
             just printing to stdout/stderr.
         """
-        self.get_lock().acquire()
-        hard_timeout_delta: int
-        if loglevel not in self.hard_timeout_deltas:
-            log_fn(
-                f"{WARN_PREFIX} log level {loglevel} not in self.hard_timeout_deltas; defaulting"
-                " to _HARD_TIMEOUT_DELTAS[logging.INFO].\n"
-            )
-            hard_timeout_delta = CLPLogLevelTimeout._HARD_TIMEOUT_DELTAS[logging.INFO]
-        else:
-            hard_timeout_delta = self.hard_timeout_deltas[loglevel]
+        with self.get_lock():
+            hard_timeout_delta: int
+            if loglevel not in self.hard_timeout_deltas:
+                log_fn(
+                    f"{WARN_PREFIX} log level {loglevel} not in self.hard_timeout_deltas; "
+                    "defaulting to _HARD_TIMEOUT_DELTAS[logging.INFO].\n"
+                )
+                hard_timeout_delta = CLPLogLevelTimeout._HARD_TIMEOUT_DELTAS[logging.INFO]
+            else:
+                hard_timeout_delta = self.hard_timeout_deltas[loglevel]
 
-        new_hard_timeout_ts: int = log_timestamp_ms + hard_timeout_delta
-        if new_hard_timeout_ts < self.next_hard_timeout_ts:
-            if self.hard_timeout_thread:
-                self.hard_timeout_thread.cancel()
-            self.hard_timeout_thread = Timer(new_hard_timeout_ts / 1000 - time.time(), self.timeout)
-            self.hard_timeout_thread.setDaemon(True)
-            self.hard_timeout_thread.start()
-            self.next_hard_timeout_ts = new_hard_timeout_ts
+            new_hard_timeout_ts: int = log_timestamp_ms + hard_timeout_delta
+            if new_hard_timeout_ts < self.next_hard_timeout_ts:
+                if self.hard_timeout_thread:
+                    self.hard_timeout_thread.cancel()
+                self.hard_timeout_thread = Timer(
+                    new_hard_timeout_ts / 1000 - time.time(), self.timeout
+                )
+                self.hard_timeout_thread.setDaemon(True)
+                self.hard_timeout_thread.start()
+                self.next_hard_timeout_ts = new_hard_timeout_ts
 
-        soft_timeout_delta: int
-        if loglevel not in self.soft_timeout_deltas:
-            log_fn(
-                f"{WARN_PREFIX} log level {loglevel} not in self.soft_timeout_deltas; defaulting"
-                " to _SOFT_TIMEOUT_DELTAS[logging.INFO].\n"
-            )
-            soft_timeout_delta = CLPLogLevelTimeout._SOFT_TIMEOUT_DELTAS[logging.INFO]
-        else:
-            soft_timeout_delta = self.soft_timeout_deltas[loglevel]
+            soft_timeout_delta: int
+            if loglevel not in self.soft_timeout_deltas:
+                log_fn(
+                    f"{WARN_PREFIX} log level {loglevel} not in self.soft_timeout_deltas; "
+                    "defaulting to _SOFT_TIMEOUT_DELTAS[logging.INFO].\n"
+                )
+                soft_timeout_delta = CLPLogLevelTimeout._SOFT_TIMEOUT_DELTAS[logging.INFO]
+            else:
+                soft_timeout_delta = self.soft_timeout_deltas[loglevel]
 
-        if soft_timeout_delta < self.min_soft_timeout_delta:
-            self.min_soft_timeout_delta = soft_timeout_delta
+            if soft_timeout_delta < self.min_soft_timeout_delta:
+                self.min_soft_timeout_delta = soft_timeout_delta
 
-        new_soft_timeout_ms: int = log_timestamp_ms + soft_timeout_delta
-        if self.soft_timeout_thread:
-            self.soft_timeout_thread.cancel()
-        self.soft_timeout_thread = Timer(new_soft_timeout_ms / 1000 - time.time(), self.timeout)
-        self.soft_timeout_thread.setDaemon(True)
-        self.soft_timeout_thread.start()
-        self.get_lock().release()
+            new_soft_timeout_ms: int = log_timestamp_ms + soft_timeout_delta
+            if self.soft_timeout_thread:
+                self.soft_timeout_thread.cancel()
+            self.soft_timeout_thread = Timer(new_soft_timeout_ms / 1000 - time.time(), self.timeout)
+            self.soft_timeout_thread.setDaemon(True)
+            self.soft_timeout_thread.start()
 
 
 class CLPSockListener:
@@ -462,22 +462,18 @@ class CLPSockListener:
                 if loglevel_timeout:
                     loglevel_timeout.update(loglevel, last_timestamp_ms, log_fn)
                 buf += timestamp_buf
-                if loglevel_timeout:
-                    loglevel_timeout.get_lock().acquire()
-                ostream.write(buf)
-                if loglevel_timeout:
-                    loglevel_timeout.get_lock().release()
+                with loglevel_timeout.get_lock() if loglevel_timeout else nullcontext():
+                    ostream.write(buf)
             if loglevel_timeout:
                 loglevel_timeout.timeout()
-                loglevel_timeout.get_lock().acquire()
-            ostream.write(EOF_CHAR)
 
-            if enable_compression:
-                # Since we are not using context manager, the ostream should be
-                # explicitly closed.
-                ostream.close()
-            if loglevel_timeout:
-                loglevel_timeout.get_lock().release()
+            with loglevel_timeout.get_lock() if loglevel_timeout else nullcontext():
+                ostream.write(EOF_CHAR)
+
+                if enable_compression:
+                    # Since we are not using context manager, the ostream should be
+                    # explicitly closed.
+                    ostream.close()
         # tell _server to exit
         CLPSockListener._signaled = True
         return 0
@@ -755,11 +751,8 @@ class CLPStreamHandler(CLPBaseHandler):
             raise RuntimeError("Stream already closed")
         clp_msg: bytearray
         clp_msg, self.last_timestamp_ms = _encode_log_event(msg, self.last_timestamp_ms)
-        if self.loglevel_timeout:
-            self.loglevel_timeout.get_lock().acquire()
-        self.ostream.write(clp_msg)
-        if self.loglevel_timeout:
-            self.loglevel_timeout.get_lock().release()
+        with self.loglevel_timeout.get_lock() if self.loglevel_timeout else nullcontext():
+            self.ostream.write(clp_msg)
 
     # override
     def _write(self, loglevel: int, msg: str) -> None:
@@ -769,10 +762,8 @@ class CLPStreamHandler(CLPBaseHandler):
         clp_msg, self.last_timestamp_ms = _encode_log_event(msg, self.last_timestamp_ms)
         if self.loglevel_timeout:
             self.loglevel_timeout.update(loglevel, self.last_timestamp_ms, self._direct_write)
-            self.loglevel_timeout.get_lock().acquire()
-        self.ostream.write(clp_msg)
-        if self.loglevel_timeout:
-            self.loglevel_timeout.get_lock().release()
+        with self.loglevel_timeout.get_lock() if self.loglevel_timeout else nullcontext():
+            self.ostream.write(clp_msg)
 
     # Added to logging.StreamHandler in python 3.7
     # override
@@ -797,11 +788,9 @@ class CLPStreamHandler(CLPBaseHandler):
     def close(self) -> None:
         if self.loglevel_timeout:
             self.loglevel_timeout.timeout()
-            self.loglevel_timeout.get_lock().acquire()
-        self.ostream.write(EOF_CHAR)
-        self.ostream.close()
-        if self.loglevel_timeout:
-            self.loglevel_timeout.get_lock().release()
+        with self.loglevel_timeout.get_lock() if self.loglevel_timeout else nullcontext():
+            self.ostream.write(EOF_CHAR)
+            self.ostream.close()
         self.closed = True
         super().close()
 

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -316,12 +316,11 @@ def _get_mutex_context_from_loglevel_timeout(
     loglevel_timeout: Optional[CLPLogLevelTimeout],
 ) -> AbstractContextManager[Optional[bool]]:
     """
-    Returns a context manager from the lock given by `loglevel_timeout`. If
-    `loglevel_timeout` is `None`, it returns a `nullcontext()` instead.
+    Gets a mutual exclusive context manager for IR stream access.
 
     :param loglevel_timeout: An optional `CLPLogLevelTimeout` object.
-    :return: The lock from `loglevel_timeout` if it is not `None`,
-        or a `nullcontext()` if it is `None`.
+    :return: A context manager that either provides the lock from
+        `loglevel_timeout` or a `nullcontext` if `loglevel_timeout` is `None`.
     """
     return loglevel_timeout.get_lock() if loglevel_timeout else nullcontext()
 

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -10,7 +10,7 @@ from math import floor
 from pathlib import Path
 from queue import Empty, Queue
 from signal import SIGINT, signal, SIGTERM
-from threading import Thread, Timer
+from threading import Lock, Thread, Timer
 from types import FrameType
 from typing import Any, Callable, ClassVar, Dict, IO, Optional, Tuple, Union
 
@@ -87,6 +87,27 @@ def _encode_log_event(msg: str, last_timestamp_ms: int) -> Tuple[bytearray, int]
         timestamp_ms - last_timestamp_ms, msg.encode()
     )
     return clp_msg, timestamp_ms
+
+
+class _LockedStream:
+    """
+    A wrapper class for output streams that locks before `write` or `flush`.
+    """
+
+    def __init__(self, stream: Union[ZstdCompressionWriter, IO[bytes]]) -> None:
+        self._stream: Union[ZstdCompressionWriter, IO[bytes]] = stream
+        self._lock: Lock = Lock()
+
+    def write(self, b: Union[bytes, bytearray]) -> int:
+        with self._lock:
+            return self._stream.write(b)
+
+    def flush(self) -> None:
+        with self._lock:
+            self._stream.flush()
+
+    def close(self) -> None:
+        self._stream.close()
 
 
 class CLPBaseHandler(logging.Handler, metaclass=ABCMeta):
@@ -223,11 +244,11 @@ class CLPLogLevelTimeout:
         self.timeout_fn: Callable[[], None] = timeout_fn
         self.next_hard_timeout_ts: int = ULONG_MAX
         self.min_soft_timeout_delta: int = ULONG_MAX
-        self.ostream: Optional[Union[ZstdCompressionWriter, IO[bytes]]] = None
+        self.ostream: Optional[_LockedStream] = None
         self.hard_timeout_thread: Optional[Timer] = None
         self.soft_timeout_thread: Optional[Timer] = None
 
-    def set_ostream(self, ostream: Union[ZstdCompressionWriter, IO[bytes]]) -> None:
+    def set_ostream(self, ostream: _LockedStream) -> None:
         self.ostream = ostream
 
     def timeout(self) -> None:
@@ -421,7 +442,7 @@ class CLPSockListener:
 
         with log_path.open("ab") as log:
             # Since the compression may be disabled, context manager is not used
-            ostream: Union[ZstdCompressionWriter, IO[bytes]] = (
+            ostream: _LockedStream = _LockedStream(
                 cctx.stream_writer(log) if enable_compression else log
             )
 
@@ -702,7 +723,7 @@ class CLPStreamHandler(CLPBaseHandler):
 
     def init(self, stream: IO[bytes]) -> None:
         self.cctx: ZstdCompressor = ZstdCompressor()
-        self.ostream: Union[ZstdCompressionWriter, IO[bytes]] = (
+        self.ostream: _LockedStream = _LockedStream(
             self.cctx.stream_writer(stream) if self.enable_compression else stream
         )
         self.last_timestamp_ms: int = floor(time.time() * 1000)  # convert to ms and truncate

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -102,12 +102,17 @@ class _LockedStream:
         with self._lock:
             return self._stream.write(b)
 
-    def flush(self) -> None:
+    def flush(self, flush_mode: Optional[int] = None) -> None:
         with self._lock:
-            self._stream.flush()
+            if flush_mode is None:
+                self._stream.flush()
+            else:
+                assert isinstance(self._stream, ZstdCompressionWriter)
+                self._stream.flush(flush_mode)
 
     def close(self) -> None:
-        self._stream.close()
+        with self._lock:
+            self._stream.close()
 
 
 class CLPBaseHandler(logging.Handler, metaclass=ABCMeta):

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -316,9 +316,9 @@ def _get_mutex_context_from_loglevel_timeout(loglevel_timeout: Optional[CLPLogLe
     """
     Gets a mutual exclusive context manager for IR stream access.
 
-    The return type should be `AbstractContextManager[Optional[bool]]`, but it
-    is annotated as `Any` for backward compatibility, since the generic
-    `AbstractContextManager` is not available before Python 3.9 (#18239).
+    NOTE: The return type should be `AbstractContextManager[Optional[bool]]`,
+    but it is annotated as `Any` to satisfy the linter in Python 3.7 and 3.8,
+    as `AbstractContextManager` was introduced in Python 3.9 (#18239).
 
     :param loglevel_timeout: An optional `CLPLogLevelTimeout` object.
     :return: A context manager that either provides the lock from

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -314,7 +314,7 @@ class CLPLogLevelTimeout:
 
 def _get_mutex_context_from_loglevel_timeout(
     loglevel_timeout: Optional[CLPLogLevelTimeout],
-) -> AbstractContextManager[bool | None]:
+) -> AbstractContextManager[Optional[bool]]:
     """
     Returns a context manager from the lock given by `loglevel_timeout`. If
     `loglevel_timeout` is `None`, it returns a `nullcontext()` instead.

--- a/src/clp_logging/handlers.py
+++ b/src/clp_logging/handlers.py
@@ -5,7 +5,7 @@ import sys
 import time
 import warnings
 from abc import ABCMeta, abstractmethod
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import nullcontext
 from math import floor
 from pathlib import Path
 from queue import Empty, Queue


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR fixes #55 by adding a wrapper class, `_LockedStream`, around `ZstdCompressionWriter` or `IO[bytes]`. It ensures thread safety by wrapping the `write` and `flush` methods with a lock.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

All unit tests have passed.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the logging system to deliver more reliable output during simultaneous operations, ensuring smoother and more consistent logging performance for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->