### PR TITLE
docs: Add warning about ClpKeyValuePairStreamHandler's incompatibility with other handlers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ dictionaries, where each dictionary entry must abide by the requirements detaile
 [metadata](#automatically-generated-kv-pairs) (e.g., the log event's level) with each log event.
 
 > [!WARNING]
-> This handler cannot be used with other logging handlers since it requires the `msg` argument
-> passed to the logging method to be a dictionary. In contrast, standard handlers typically treat
-> `msg` as a format string. In the future, this handler may be moved or reworked to avoid confusion.
+> This handler cannot be used with other logging handlers since it requires `msg` (the first
+> argument passed to the logging method) to be a dictionary. In contrast, standard handlers
+> typically treat `msg` as a format string. In the future, this handler may be moved or reworked to
+> avoid confusion.
 
 > [!NOTE]
 > Since this handler accepts structured log events, it doesn't support setting a

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ dictionaries, where each dictionary entry must abide by the requirements detaile
 [below](#key-value-pair-requirements). The handler will also automatically include certain
 [metadata](#automatically-generated-kv-pairs) (e.g., the log event's level) with each log event.
 
+> [!WARNING]
+> This handler cannot be used with other logging handlers since it requires that the `msg` argument
+> passed to the logging method is a dictionary, whereas other handlers expect the `msg` argument to
+> be a format string. In the future, this handler may be moved to another library to avoid
+> confusion.
+
 > [!NOTE]
 > Since this handler accepts structured log events, it doesn't support setting a
 > [Formatter][py-logging-formatter] (because the log events don't need to be formatted into a

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ dictionaries, where each dictionary entry must abide by the requirements detaile
 [metadata](#automatically-generated-kv-pairs) (e.g., the log event's level) with each log event.
 
 > [!WARNING]
-> This handler cannot be used with other logging handlers since it requires that the `msg` argument
-> passed to the logging method is a dictionary, whereas other handlers expect the `msg` argument to
-> be a format string. In the future, this handler may be moved or reworked to avoid confusion.
+> This handler cannot be used with other logging handlers since it requires the `msg` argument
+> passed to the logging method to be a dictionary. In contrast, standard handlers typically treat
+> `msg` as a format string. In the future, this handler may be moved or reworked to avoid confusion.
 
 > [!NOTE]
 > Since this handler accepts structured log events, it doesn't support setting a

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ dictionaries, where each dictionary entry must abide by the requirements detaile
 > [!WARNING]
 > This handler cannot be used with other logging handlers since it requires that the `msg` argument
 > passed to the logging method is a dictionary, whereas other handlers expect the `msg` argument to
-> be a format string. In the future, this handler may be moved to another library to avoid
-> confusion.
+> be a format string. In the future, this handler may be moved or reworked to avoid confusion.
 
 > [!NOTE]
 > Since this handler accepts structured log events, it doesn't support setting a


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As @junhaoliao reported offline, the ClpKeyValuePairStreamHandler is incompatible with other handlers since it requires the `msg` argument passed to the logging methods to be a dictionary whereas other handlers require that it's a format string. After discussing it offline with @LinZhihao-723, we decided to warn users for now and eventually develop a better solution that doesn't violate Python's logging handler conventions.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Validated the addition to the README looks correct on GitHub.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a warning to the documentation for the `ClpKeyValuePairStreamHandler` logging handler about incompatibility with other logging handlers and potential future changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->